### PR TITLE
Remove external Hugo theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "themes/hello-friend-ng"]
-	path = themes/hello-friend-ng
-	url = https://github.com/tphummel/hugo-theme-hello-friend-ng.git

--- a/config.toml
+++ b/config.toml
@@ -3,7 +3,6 @@ title   = "Tom Hummel"
 
 DefaultContentLanguage = "en"
 
-theme = "hello-friend-ng"
 
 PygmentsCodeFences = true
 PygmentsStyle = "monokai"

--- a/content/colophon.md
+++ b/content/colophon.md
@@ -7,7 +7,7 @@ Also known as: how is this website built?
 
 # September 2024
 
-This website is built with [hugo][0]. The code for the website itself is [hosted on github][1]. The website is hosted in [cloudflare pages][2]. The domain is registered with cloudflare. The infrastructure plumbling code is [hosted on github][3] and uses [Terraform][6] run from my local workstation. I use a [fork][4] of a Hugo theme called [Hello Friend NG][5]. I forked the theme so I could get some additional hook points to customize my website. In the future, I expect I'll move off of an external theme to something minimal which lives entirely in my code. 
+This website is built with [hugo][0]. The code for the website itself is [hosted on github][1]. The website is hosted in [cloudflare pages][2]. The domain is registered with cloudflare. The infrastructure plumbing code is [hosted on github][3] and uses [Terraform][6] run from my local workstation. I previously used a [fork][4] of a Hugo theme called [Hello Friend NG][5] so I could get some additional hook points to customize my website. I have since moved to a very small theme that includes [water.css](https://watercss.kognise.dev/) and lives entirely in this repository.
 
 I use [Honeycomb][7] called by [Cloudflare Workers][9] for [server-side pageview analytics][8].
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>{{ block "title" . }}{{ .Site.Title }}{{ end }}</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.css">
+    {{ partial "extra-head.html" . }}
+</head>
+<body>
+<header>
+    <h1><a href="{{ "/" | relURL }}">{{ .Site.Title }}</a></h1>
+</header>
+<main>
+    {{ block "main" . }}{{ end }}
+</main>
+</body>
+</html>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,0 +1,14 @@
+{{ define "title" }}{{ .Title }} | {{ .Site.Title }}{{ end }}
+{{ define "main" }}
+<article>
+  <h1>{{ .Title }}</h1>
+  {{ .Content }}
+  {{ if .Pages }}
+  <ul>
+  {{ range .Pages }}
+    <li><a href="{{ .RelPermalink }}">{{ .Title }}</a> - {{ .Date.Format "2006-01-02" }}</li>
+  {{ end }}
+  </ul>
+  {{ end }}
+</article>
+{{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,0 +1,17 @@
+{{ define "title" }}{{ .Title }} | {{ .Site.Title }}{{ end }}
+{{ define "main" }}
+<article>
+  <h1>{{ .Title }}</h1>
+  {{ .Content }}
+  <footer>
+    <p>
+      Posted {{ .Date.Format "2006-01-02" }} |
+      {{ .WordCount }} words{{ with .GitInfo }} |
+      Updated {{ .AuthorDate.Format "2006-01-02" }} @ {{ .AbbreviatedHash }}{{ end }}
+      {{ with .Params.tags }} |
+      Tags: {{ range $i, $tag := . }}{{ if $i }}, {{ end }}<a href="{{ "/tags/" | relURL }}{{ $tag | urlize }}">{{ $tag }}</a>{{ end }}
+      {{ end }}
+    </p>
+  </footer>
+</article>
+{{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,0 +1,3 @@
+{{ define "main" }}
+{{ partial "extra-index.html" . }}
+{{ end }}


### PR DESCRIPTION
## Summary
- remove git submodule for `hello-friend-ng`
- drop the `theme` setting from `config.toml`
- create minimal layouts and stylesheet
- update colophon to mention custom theme
- use water.css instead of local stylesheet
- show post metadata in the footer
- list pages now show content and posts
- show word count and commit info in metadata

## Testing
- `hugo >/tmp/hugo.log && tail -n 20 /tmp/hugo.log`


------
https://chatgpt.com/codex/tasks/task_e_6863716ec03c83239c8fbdcaa271c24f