### PR TITLE
Customize self‑hosted water.css

### DIFF
--- a/content/colophon.md
+++ b/content/colophon.md
@@ -7,7 +7,7 @@ Also known as: how is this website built?
 
 # September 2024
 
-This website is built with [hugo][0]. The code for the website itself is [hosted on github][1]. The website is hosted in [cloudflare pages][2]. The domain is registered with cloudflare. The infrastructure plumbing code is [hosted on github][3] and uses [Terraform][6] run from my local workstation. I previously used a [fork][4] of a Hugo theme called [Hello Friend NG][5] so I could get some additional hook points to customize my website. I have since moved to a very small theme that includes [water.css](https://watercss.kognise.dev/) and lives entirely in this repository.
+This website is built with [hugo][0]. The code for the website itself is [hosted on github][1]. The website is hosted in [cloudflare pages][2]. The domain is registered with cloudflare. The infrastructure plumbing code is [hosted on github][3] and uses [Terraform][6] run from my local workstation. I previously used a [fork][4] of a Hugo theme called [Hello Friend NG][5] so I could get some additional hook points to customize my website. I have since moved to a very small theme that includes a simplified, self-hosted variant of water.css and lives entirely in this repository.
 
 I use [Honeycomb][7] called by [Cloudflare Workers][9] for [server-side pageview analytics][8].
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>{{ block "title" . }}{{ .Site.Title }}{{ end }}</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.css">
+    <link rel="stylesheet" href="/css/water.css">
     {{ partial "extra-head.html" . }}
 </head>
 <body>

--- a/static/css/water.css
+++ b/static/css/water.css
@@ -1,0 +1,52 @@
+/* Simplified Water.css for compatibility */
+:root {
+  color-scheme: light dark;
+  --background-body: #ffffff;
+  --text-main: #000000;
+  --text-link: #0645ad;
+  --text-link-visited: #0b0080;
+  --text-link-hover: #f00;
+  --text-selection: #b3d4fc;
+  --background-alt: #f5f5f5;
+  --border: #ddd;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background-body: #121212;
+    --text-main: #e4e4e4;
+    --text-link: #9cf;
+    --text-link-visited: #c9f;
+    --background-alt: #1e1e1e;
+    --border: #333;
+  }
+}
+html {
+  line-height: 1.5;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+}
+body {
+  margin: 0 auto;
+  max-width: 800px;
+  padding: 1rem;
+  background: var(--background-body);
+  color: var(--text-main);
+}
+a {
+  color: var(--text-link);
+}
+a:visited {
+  color: var(--text-link-visited);
+}
+a:hover {
+  color: var(--text-link-hover);
+}
+pre, code {
+  font-family: ui-monospace, "SFMono-Regular", "Menlo", "Consolas", "Liberation Mono", monospace;
+}
+table {
+  border-collapse: collapse;
+}
+th, td {
+  padding: 0.5rem;
+  border: 1px solid var(--border);
+}


### PR DESCRIPTION
## Summary
- add `static/css/water.css` with a simple compatibility-focused style
- reference the local stylesheet in the base layout
- note the self-hosted variant in the colophon

## Testing
- `hugo --minify`

------
https://chatgpt.com/codex/tasks/task_e_686cb00ae43c8323960a4889ea0418a8