### PR TITLE
Use relative Hugo links

### DIFF
--- a/content/experiments.md
+++ b/content/experiments.md
@@ -3,6 +3,6 @@ title: "Experiments"
 date: 2020-09-01T08:00:00
 ---
 
-- [math game](/math-game)
-- [magic eight ball](/eight-ball)
-- [Fidget Toy](/fidget)
+- [math game]({{ "math-game" | relURL }})
+- [magic eight ball]({{ "eight-ball" | relURL }})
+- [Fidget Toy]({{ "fidget" | relURL }})

--- a/content/posts/double-dash-analysis-part-1.md
+++ b/content/posts/double-dash-analysis-part-1.md
@@ -143,9 +143,9 @@ __Most Common Driver Pairs__ (min. 50 races)
 
 Diddy Kong and Toadette were a monster team, finishing 1st or 2nd in 108 of 145 races they started.
 
-  [0]: {{< ref exfiltrating-mario-kart-data-from-google-app-engine >}}
+  [0]: {{< relref exfiltrating-mario-kart-data-from-google-app-engine >}}
   [1]: https://github.com/tphummel/junk/blob/master/gaej-kart/script/data/csv
-  [2]: {{< ref mario-kart-primer >}}
+  [2]: {{< relref mario-kart-primer >}}
   [3]: https://github.com/tphummel/junk/blob/master/gaej-kart/script/data/README.md
   [4]: https://harelba.github.io/q/
   [5]: https://github.com/tphummel/junk/blob/master/gaej-kart/script/data/reports/README.md

--- a/content/posts/double-dash-analysis-part-2.md
+++ b/content/posts/double-dash-analysis-part-2.md
@@ -164,5 +164,5 @@ __Standings by Course__
 |Yoshi Circuit|Tom|33|20|11|1|0|1|0|0|0|297|
 |Yoshi Circuit|Nick|33|13|20|0|0|0|0|0|0|290|
 
-  [0]: {{< ref double-dash-analysis-part-1 >}}
-  [1]: {{< ref mario-kart-primer >}}
+  [0]: {{< relref double-dash-analysis-part-1 >}}
+  [1]: {{< relref mario-kart-primer >}}

--- a/content/posts/exfiltrating-mario-kart-data-from-google-app-engine.md
+++ b/content/posts/exfiltrating-mario-kart-data-from-google-app-engine.md
@@ -81,8 +81,8 @@ And just like that I have the [data][14] out. I wish I had just started with app
 
 I think the lesson here is that if I'm going to use a PaaS I can't create something, walk away from it for two years, and expect everything to be peachy when I try to make a change (however small I may think it is). And I don't think I will be choosing to use Java anytime soon, given the option. All the same adios GAE we had a good run.
 
-  [0]: {{< ref tetris-primer >}}
-  [3]: {{< ref mario-kart-primer >}}
+  [0]: {{< relref tetris-primer >}}
+  [3]: {{< relref mario-kart-primer >}}
   [4]: https://developers.google.com/appengine/docs/java/gettingstarted/installing
   [5]: https://developers.google.com/appengine/docs/java/tools/eclipse
   [6]: https://developers.google.com/eclipse/docs/existingprojects

--- a/content/posts/front-page-hacker-news.md
+++ b/content/posts/front-page-hacker-news.md
@@ -15,7 +15,7 @@ tags:
 
 I wrote [a blog post]({{< relref "posts/four-web-apps.md" >}}) in February 2023. It became by far the most popular content I've personally put on the internet. I love when [others share this stuff](https://www.swyx.io/ranking-1-on-hn-in-mid-april) so I've included some background on what happened before, during, and after.
 
-[![Four Ways to Build Web Apps](/img/four-web-apps/post-min.png "Four Ways to Build Web Apps")]({{< relref "posts/four-web-apps.md" >}})
+[![Four Ways to Build Web Apps]({{ "img/four-web-apps/post-min.png" | relURL }} "Four Ways to Build Web Apps")]({{< relref "posts/four-web-apps.md" >}})
 
 ## Highlights
 
@@ -28,13 +28,13 @@ I wrote [a blog post]({{< relref "posts/four-web-apps.md" >}}) in February 2023.
 ## Charts
 
 ### Pageviews Overview
-![Seven Day Pageviews](/img/four-web-apps/honeycomb-overview-min.png "Data from honeycomb")
+![Seven Day Pageviews]({{ "img/four-web-apps/honeycomb-overview-min.png" | relURL }} "Data from honeycomb")
 
 ### Pageviews Zoomed
-![Four Day Pageviews](/img/four-web-apps/honeycomb-zoom-min.png "Data from honeycomb")
+![Four Day Pageviews]({{ "img/four-web-apps/honeycomb-zoom-min.png" | relURL }} "Data from honeycomb")
 
 ### Hacker News Ranking
-![Hacker News Rankings](/img/four-web-apps/hacker-news-ranking-min.png "Post reached top 5 on HN")
+![Hacker News Rankings]({{ "img/four-web-apps/hacker-news-ranking-min.png" | relURL }} "Post reached top 5 on HN")
 
 ### Pct of Traffic By Country
 (from Cloudflare, First 48 Hours)
@@ -67,7 +67,7 @@ There is no question this exposure radiated outward to a number of my other post
 
 ## Technical Details
 
-[My blog](https://tomhummel.com) is a [static website](https://github.com/tphummel/blog/) built with [Hugo](https://gohugo.io), hosted on [Cloudflare Pages](https://pages.cloudflare.com/) (Way #1), augmented with a Cloudflare Worker (Way #2). [The worker](https://github.com/tphummel/blog/blob/main/workers/index.js) intercepts each request, sends the request to its original destination, sends analytics data to [Honeycomb](https://honeycomb.io), and sets two security headers on the response.
+[My blog]({{ "/" | relURL }}) is a [static website](https://github.com/tphummel/blog/) built with [Hugo](https://gohugo.io), hosted on [Cloudflare Pages](https://pages.cloudflare.com/) (Way #1), augmented with a Cloudflare Worker (Way #2). [The worker](https://github.com/tphummel/blog/blob/main/workers/index.js) intercepts each request, sends the request to its original destination, sends analytics data to [Honeycomb](https://honeycomb.io), and sets two security headers on the response.
 
 The tools available on Honeycomb's generous free tier are what unlocked the analysis in this post. Coarse grained data was available on Cloudflare but not sufficient to do everything.
 

--- a/content/posts/game-boy-advance-buying-guide.md
+++ b/content/posts/game-boy-advance-buying-guide.md
@@ -101,8 +101,7 @@ Here is an overview of the 228 Nintendo Game Boy Advance games rated 70 or above
 
 ## Background & Methodology
 
-See [Nintendo DS Buying Guide]({{< ref nintendo-ds-buying-guide >}}) for background and methodology. It applies equally here.
+See [Nintendo DS Buying Guide]({{< relref nintendo-ds-buying-guide >}}) for background and methodology. It applies equally here.
 
 ### Data
-
-- [metacritic dataset (gen 5,6,7 + wii u)](/files/metacritic-gen5-6-7.csv)
+- [metacritic dataset (gen 5,6,7 + wii u)]({{ "files/metacritic-gen5-6-7.csv" | relURL }})

--- a/content/posts/gamecube-buying-guide.md
+++ b/content/posts/gamecube-buying-guide.md
@@ -123,10 +123,9 @@ See [Nintendo DS Buying Guide][1] for background and methodology. It applies equ
 
 ### Data
 
-- [metacritic dataset (gen 5,6,7 + wii u)](/files/metacritic-gen5-6-7.csv)
+ - [metacritic dataset (gen 5,6,7 + wii u)]({{ "files/metacritic-gen5-6-7.csv" | relURL }})
 
 
-  [0]: {{< ref game-boy-advance-buying-guide >}}
-  [1]: {{< ref nintendo-ds-buying-guide >}}
-  [2]: https://metacritic.com
-  [3]: https://www.pricecharting.com/
+  [0]: {{< relref game-boy-advance-buying-guide >}}
+  [1]: {{< relref nintendo-ds-buying-guide >}}
+  [2]: https://metacritic.com  [3]: https://www.pricecharting.com/

--- a/content/posts/jekyll-to-hugo.md
+++ b/content/posts/jekyll-to-hugo.md
@@ -199,7 +199,7 @@ content/posts/tetris-primer.md
   [12]: https://github.com/tphummel/blog/blob/1ad3d9e24449557e2f710faf1c8353bd30607b9e/config.toml
   [13]: https://github.com/tphummel/blog/commit/17b813c8c981d5915fecd5d207de2c264bde2fbb#diff-354f30a63fb0907d4ad57269548329e3
   [14]: https://github.com/tphummel/blog/commit/17b813c8c981d5915fecd5d207de2c264bde2fbb#diff-b67911656ef5d18c4ae36cb6741b7965
-  [15]: https://tomhummel.com/ci.json
+  [15]: {{ "ci.json" | relURL }}
   [16]: https://github.com/Track3/hermit
   [17]: https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity
   [18]: https://cloudflare.com

--- a/content/posts/latex-record-book.md
+++ b/content/posts/latex-record-book.md
@@ -14,6 +14,6 @@ I wanted to create a record book with [LaTeX][4] for a [game][2] my friends and 
 
   [0]: https://docs.google.com/presentation/d/1Bp0GEOicPxpYAnrw1AsL_jlwXiM_CENWsjuw2v0LEpo/edit
   [1]: https://github.com/tphummel/tetris-latex
-  [2]: {{< ref tetris-primer >}}
-  [3]: /files/tetris-book-v1.pdf
+  [2]: {{< relref tetris-primer >}}
+  [3]: {{ "files/tetris-book-v1.pdf" | relURL }}
   [4]: https://en.wikipedia.org/wiki/LaTeX

--- a/content/posts/mario-kart-primer.md
+++ b/content/posts/mario-kart-primer.md
@@ -52,11 +52,11 @@ The basic structure of the site allows you to create a league. The league has lo
 
 As of 2012 the system has collected over 1000 races.
 
-EDIT: 2013-05-12. I've taken down the GAE app. I broke it while [extracting its historical data]({{< ref exfiltrating-mario-kart-data-from-google-app-engine >}}).
+EDIT: 2013-05-12. I've taken down the GAE app. I broke it while [extracting its historical data]({{< relref exfiltrating-mario-kart-data-from-google-app-engine >}}).
 
-EDIT: 2016-01-04. I've done [some analysis]({{< ref double-dash-analysis-part-1 >}}) on the extracted data.
+EDIT: 2016-01-04. I've done [some analysis]({{< relref double-dash-analysis-part-1 >}}) on the extracted data.
 
-EDIT: 2016-01-11. I've done [even more analysis]({{< ref double-dash-analysis-part-2 >}}) on the extracted data.
+EDIT: 2016-01-11. I've done [even more analysis]({{< relref double-dash-analysis-part-2 >}}) on the extracted data.
 
   [0]: http://en.wikipedia.org/wiki/Mario_Kart:_Double_Dash%E2%80%BC
   [1]: http://babyparkdd.appspot.com/

--- a/content/posts/nintendo-ds-buying-guide.md
+++ b/content/posts/nintendo-ds-buying-guide.md
@@ -247,4 +247,4 @@ I assigned an id to each game in price charting download. i used that id to map 
 
 ### Data 
 
-- [metacritic dataset (gen 5,6,7 + wii u)](/files/metacritic-gen5-6-7.csv)
+- [metacritic dataset (gen 5,6,7 + wii u)]({{ "files/metacritic-gen5-6-7.csv" | relURL }})

--- a/content/posts/realtime-data-client.md
+++ b/content/posts/realtime-data-client.md
@@ -45,7 +45,7 @@ More web clients consuming the websocket events. Or a dashboard of graphics each
 
 
   [0]: https://github.com/tphummel/tetris-db
-  [1]: {{< ref tetris-primer >}}
+  [1]: {{< relref tetris-primer >}}
   [2]: https://redis.io/topics/pubsub
   [4]: https://d3js.org/
   [5]: https://github.com/tphummel/junk/tree/master/socket-viz

--- a/content/posts/super-metroid-100-percent.md
+++ b/content/posts/super-metroid-100-percent.md
@@ -147,4 +147,4 @@ It might even be too streamlined. If so, you should switch to one of the many ot
 
 ## Files
 
-- Download checklist as [xlsx](/files/super-metroid-100-checklist.xlsx), [csv](/files/super-metroid-100-checklist.csv).
+- Download checklist as [xlsx]({{ "files/super-metroid-100-checklist.xlsx" | relURL }}), [csv]({{ "files/super-metroid-100-checklist.csv" | relURL }}).

--- a/content/posts/using-r-with-mysql-data.md
+++ b/content/posts/using-r-with-mysql-data.md
@@ -62,5 +62,5 @@ hist(df1$ratio, 100,
 {{< figure src=/img/KqmmL5w.png title="R Histogram" alt="R Histogram" >}}
 
 
-  [0]: {{< ref tetris-primer >}}
+  [0]: {{< relref tetris-primer >}}
   [1]: https://cran.r-project.org/


### PR DESCRIPTION
## Summary
- make content links use `relref` for pages and `relURL` for assets
- keep links working on preview deployments

## Testing
- `hugo --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686dfa35dd688323a1a6142e8ed010cf