### PR TITLE
Add shortcodes for Pounce and Tetris posts

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -31,11 +31,13 @@ enableRobotsTXT = true
 enableGitInfo   = true
 enableEmoji     = true
 enableMissingTranslationPlaceholders = false
-enableInlineShortcodes = true
 disableRSS     = false
 disableSitemap = false
 disable404     = false
 disableHugoGeneratorInject = false
+
+[security]
+  enableInlineShortcodes = true
 
 [permalinks]
   posts = "/posts/:title/"


### PR DESCRIPTION
## Summary
- add reusable shortcode templates for Pounce and Tetris game data
- replace inline shortcode blocks in related posts with new shortcodes to render content
- enable inline shortcodes in site config
- remove duplicate shortcode invocations so content renders only once

## Testing
- `./.asdf-local/bin/asdf exec hugo`


------
https://chatgpt.com/codex/tasks/task_e_68917bdcd7f08323bed3ff132ccd5625