### PR TITLE
Display counter metadata in fidget toy

### DIFF
--- a/static/fidget/index.html
+++ b/static/fidget/index.html
@@ -109,7 +109,7 @@
         let expiringSoon = false;
         if (expiresAt !== undefined) {
             const [display, full] = formatDate(expiresAt);
-            rows.push(['Expired', display, full]);
+            rows.push(['Expires', display, full]);
             const diff = new Date(expiresAt).getTime() - Date.now();
             if (diff < 30 * 24 * 60 * 60 * 1000) {
                 expiringSoon = true;

--- a/static/fidget/index.html
+++ b/static/fidget/index.html
@@ -15,6 +15,10 @@
             padding: 10px;
             font-size: 16px;
         }
+        .metadata {
+            display: block;
+            font-size: 0.8em;
+        }
     </style>
 </head>
 <body>
@@ -73,6 +77,22 @@
     </div>
 
 <script>
+    function updateButtonContent(button, data) {
+        let metaHTML = '';
+        if (data.metadata) {
+            let metaString = '';
+            if (typeof data.metadata === 'object' && data.metadata !== null) {
+                metaString = Object.entries(data.metadata)
+                    .map(([key, value]) => `${key}: ${value}`)
+                    .join(', ');
+            } else {
+                metaString = data.metadata;
+            }
+            metaHTML = `<span class="metadata">${metaString}</span>`;
+        }
+        button.innerHTML = `<span class="count">${data.count}</span>${metaHTML}`;
+    }
+
     // Select all counter buttons
     const counterButtons = document.querySelectorAll('.counter-button');
 
@@ -90,7 +110,7 @@
                         'Origin': window.location.origin
                     }
                 });
-                
+
                 if (!response.ok) {
                     throw new Error(`HTTP error! status: ${response.status}`);
                 }
@@ -98,8 +118,8 @@
                 // Parse the JSON response
                 const data = await response.json();
 
-                // Update the button text with the new count
-                button.textContent = data.count;
+                // Update the button text with the new count and metadata
+                updateButtonContent(button, data);
             } catch (error) {
                 console.error('Error bumping counter:', error);
                 alert(`Failed to bump counter: ${error.message}`);
@@ -121,7 +141,7 @@
             return response.json();
         })
         .then(data => {
-            button.textContent = data.count;
+            updateButtonContent(button, data);
         })
         .catch(error => {
             console.error('Error fetching initial count:', error);

--- a/static/fidget/index.html
+++ b/static/fidget/index.html
@@ -12,8 +12,12 @@
             margin: 0 auto;
         }
         .counter-button {
-            padding: 10px;
+            padding: 16px;
             font-size: 16px;
+        }
+        .counter-button .count {
+            display: block;
+            font-size: 1.5em;
         }
         .payload {
             font-size: 0.8em;
@@ -85,17 +89,14 @@
         const { count, created, updated, _meta } = data;
         const rows = [];
         if (created?.at !== undefined) {
-            rows.push(['Created At', created.at]);
-        }
-        if (created?.by !== undefined) {
-            rows.push(['Created By', created.by]);
+            rows.push(['Created', created.at]);
         }
         if (updated?.at !== undefined) {
-            rows.push(['Updated At', updated.at]);
+            rows.push(['Updated', updated.at]);
         }
         const expiresAt = _meta?.expires?.at;
         if (expiresAt !== undefined) {
-            rows.push(['Expires At', expiresAt]);
+            rows.push(['Expired', expiresAt]);
         }
 
         let tableHTML = '';

--- a/static/fidget/index.html
+++ b/static/fidget/index.html
@@ -12,8 +12,10 @@
             margin: 0 auto;
         }
         .counter-button {
-            padding: 16px;
             font-size: 16px;
+        }
+        .counter-button.expiring-soon {
+            color: red;
         }
         .counter-button .count {
             display: block;
@@ -88,25 +90,41 @@
     function updateButtonContent(button, data) {
         const { count, created, updated, _meta } = data;
         const rows = [];
+
+        const formatDate = (timestamp) => {
+            if (typeof timestamp !== 'string') return [timestamp, ''];
+            const dateOnly = timestamp.split('T')[0];
+            return [dateOnly, timestamp];
+        };
+
         if (created?.at !== undefined) {
-            rows.push(['Created', created.at]);
+            const [display, full] = formatDate(created.at);
+            rows.push(['Created', display, full]);
         }
         if (updated?.at !== undefined) {
-            rows.push(['Updated', updated.at]);
+            const [display, full] = formatDate(updated.at);
+            rows.push(['Updated', display, full]);
         }
         const expiresAt = _meta?.expires?.at;
+        let expiringSoon = false;
         if (expiresAt !== undefined) {
-            rows.push(['Expired', expiresAt]);
+            const [display, full] = formatDate(expiresAt);
+            rows.push(['Expired', display, full]);
+            const diff = new Date(expiresAt).getTime() - Date.now();
+            if (diff < 30 * 24 * 60 * 60 * 1000) {
+                expiringSoon = true;
+            }
         }
 
         let tableHTML = '';
         if (rows.length > 0) {
             const rowsHTML = rows
-                .map(([label, value]) => `<tr><td>${label}</td><td>${value}</td></tr>`)
+                .map(([label, value, full]) => `<tr><td>${label}</td><td title="${full}">${value}</td></tr>`)
                 .join('');
             tableHTML = `<table class="payload"><tbody>${rowsHTML}</tbody></table>`;
         }
         button.innerHTML = `<span class="count">${count}</span>${tableHTML}`;
+        button.classList.toggle('expiring-soon', expiringSoon);
     }
 
     // Select all counter buttons

--- a/static/fidget/index.html
+++ b/static/fidget/index.html
@@ -82,12 +82,21 @@
 
 <script>
     function updateButtonContent(button, data) {
-        const { count, created_at, updated_at, expires_at } = data;
-        const rows = [
-            ['Created At', created_at],
-            ['Updated At', updated_at],
-            ['Expires At', expires_at]
-        ].filter(([, value]) => value !== undefined);
+        const { count, created, updated, _meta } = data;
+        const rows = [];
+        if (created?.at !== undefined) {
+            rows.push(['Created At', created.at]);
+        }
+        if (created?.by !== undefined) {
+            rows.push(['Created By', created.by]);
+        }
+        if (updated?.at !== undefined) {
+            rows.push(['Updated At', updated.at]);
+        }
+        const expiresAt = _meta?.expires?.at;
+        if (expiresAt !== undefined) {
+            rows.push(['Expires At', expiresAt]);
+        }
 
         let tableHTML = '';
         if (rows.length > 0) {

--- a/static/fidget/index.html
+++ b/static/fidget/index.html
@@ -16,8 +16,12 @@
             font-size: 16px;
         }
         .payload {
-            display: block;
             font-size: 0.8em;
+            margin-top: 4px;
+            border-collapse: collapse;
+        }
+        .payload td {
+            padding: 0 4px;
         }
     </style>
 </head>
@@ -78,21 +82,21 @@
 
 <script>
     function updateButtonContent(button, data) {
-        const { count, ...rest } = data;
-        let payloadHTML = '';
-        const entries = Object.entries(rest);
-        if (entries.length > 0) {
-            const payloadString = entries
-                .map(([key, value]) => {
-                    if (typeof value === 'object' && value !== null) {
-                        return `${key}: ${JSON.stringify(value)}`;
-                    }
-                    return `${key}: ${value}`;
-                })
-                .join(', ');
-            payloadHTML = `<span class="payload">${payloadString}</span>`;
+        const { count, created_at, updated_at, expires_at } = data;
+        const rows = [
+            ['Created At', created_at],
+            ['Updated At', updated_at],
+            ['Expires At', expires_at]
+        ].filter(([, value]) => value !== undefined);
+
+        let tableHTML = '';
+        if (rows.length > 0) {
+            const rowsHTML = rows
+                .map(([label, value]) => `<tr><td>${label}</td><td>${value}</td></tr>`)
+                .join('');
+            tableHTML = `<table class="payload"><tbody>${rowsHTML}</tbody></table>`;
         }
-        button.innerHTML = `<span class="count">${count}</span>${payloadHTML}`;
+        button.innerHTML = `<span class="count">${count}</span>${tableHTML}`;
     }
 
     // Select all counter buttons

--- a/static/fidget/index.html
+++ b/static/fidget/index.html
@@ -15,7 +15,7 @@
             padding: 10px;
             font-size: 16px;
         }
-        .metadata {
+        .payload {
             display: block;
             font-size: 0.8em;
         }
@@ -78,19 +78,21 @@
 
 <script>
     function updateButtonContent(button, data) {
-        let metaHTML = '';
-        if (data.metadata) {
-            let metaString = '';
-            if (typeof data.metadata === 'object' && data.metadata !== null) {
-                metaString = Object.entries(data.metadata)
-                    .map(([key, value]) => `${key}: ${value}`)
-                    .join(', ');
-            } else {
-                metaString = data.metadata;
-            }
-            metaHTML = `<span class="metadata">${metaString}</span>`;
+        const { count, ...rest } = data;
+        let payloadHTML = '';
+        const entries = Object.entries(rest);
+        if (entries.length > 0) {
+            const payloadString = entries
+                .map(([key, value]) => {
+                    if (typeof value === 'object' && value !== null) {
+                        return `${key}: ${JSON.stringify(value)}`;
+                    }
+                    return `${key}: ${value}`;
+                })
+                .join(', ');
+            payloadHTML = `<span class="payload">${payloadString}</span>`;
         }
-        button.innerHTML = `<span class="count">${data.count}</span>${metaHTML}`;
+        button.innerHTML = `<span class="count">${count}</span>${payloadHTML}`;
     }
 
     // Select all counter buttons
@@ -118,7 +120,7 @@
                 // Parse the JSON response
                 const data = await response.json();
 
-                // Update the button text with the new count and metadata
+                // Update the button text with the new count and payload details
                 updateButtonContent(button, data);
             } catch (error) {
                 console.error('Error bumping counter:', error);


### PR DESCRIPTION
## Summary
- show each counter's metadata below its count
- style metadata text with smaller font

## Testing
- `./.tool-versions-setup.sh`
- `./.asdf-local/bin/asdf exec hugo`


------
https://chatgpt.com/codex/tasks/task_e_68a14445df10832392f99b5a67ed8c25