### PR TITLE
feat: host Svelte fidget toy alongside original

### DIFF
--- a/content/experiments.md
+++ b/content/experiments.md
@@ -6,3 +6,4 @@ date: 2020-09-01T08:00:00
 - [math game](/math-game)
 - [magic eight ball](/eight-ball)
 - [Fidget Toy](/fidget)
+- [Fidget Toy (Svelte)](/fidget-svelte)

--- a/static/fidget-svelte/App.svelte
+++ b/static/fidget-svelte/App.svelte
@@ -1,0 +1,108 @@
+<script>
+  const gridSize = 4;
+  const counters = [];
+  const EXPIRING_SOON_MS = 30 * 24 * 60 * 60 * 1000;
+
+  function format(ts) {
+    if (typeof ts !== 'string') return { display: ts, full: '' };
+    const dateOnly = ts.split('T')[0];
+    return { display: dateOnly, full: ts };
+  }
+
+  function expiringSoon(ts) {
+    if (!ts) return false;
+    return new Date(ts).getTime() - Date.now() < EXPIRING_SOON_MS;
+  }
+
+  async function fetchCounter(counter) {
+    try {
+      const res = await fetch(counter.getUrl, { mode: 'cors', headers: { Origin: window.location.origin } });
+      if (!res.ok) throw new Error(res.status);
+      counter.data = await res.json();
+    } catch (e) {
+      counter.error = e;
+    }
+  }
+
+  function createCounter(x, y) {
+    const id = `tph-fidget-${x}-${y}`;
+    const counter = {
+      id,
+      getUrl: `https://bumpkit.tphummel.workers.dev/bumper/${id}.json`,
+      bumpUrl: `https://bumpkit.tphummel.workers.dev/bumper/${id}/bump.json`,
+      data: { count: 0 }
+    };
+    fetchCounter(counter);
+    return counter;
+  }
+
+  for (let y = 0; y < gridSize; y++) {
+    for (let x = 0; x < gridSize; x++) {
+      counters.push(createCounter(x, y));
+    }
+  }
+
+  async function bump(counter) {
+    try {
+      const res = await fetch(counter.bumpUrl, { mode: 'cors', headers: { Origin: window.location.origin } });
+      if (!res.ok) throw new Error(res.status);
+      counter.data = await res.json();
+    } catch (e) {
+      counter.error = e;
+    }
+  }
+</script>
+
+<style>
+#buttons-container {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+  max-width: 600px;
+  margin: 0 auto;
+}
+.counter-button {
+  font-size: 16px;
+}
+.counter-button.expiring-soon {
+  color: red;
+}
+.counter-button .count {
+  display: block;
+  font-size: 1.5em;
+}
+.payload {
+  font-size: 0.8em;
+  margin-top: 4px;
+  border-collapse: collapse;
+}
+.payload td {
+  padding: 0 4px;
+}
+</style>
+
+<div id="buttons-container">
+  {#each counters as counter}
+    <button class="counter-button" on:click={() => bump(counter)} class:expiring-soon={expiringSoon(counter.data?._meta?.expires?.at)}>
+      <span class="count">{counter.data.count}</span>
+      {#if counter.data.created?.at || counter.data.updated?.at || counter.data._meta?.expires?.at}
+        <table class="payload">
+          <tbody>
+            {#if counter.data.created?.at}
+              {@const c = format(counter.data.created.at)}
+              <tr><td>Created</td><td title="{c.full}">{c.display}</td></tr>
+            {/if}
+            {#if counter.data.updated?.at}
+              {@const u = format(counter.data.updated.at)}
+              <tr><td>Updated</td><td title="{u.full}">{u.display}</td></tr>
+            {/if}
+            {#if counter.data._meta?.expires?.at}
+              {@const e = format(counter.data._meta.expires.at)}
+              <tr><td>Expires</td><td title="{e.full}">{e.display}</td></tr>
+            {/if}
+          </tbody>
+        </table>
+      {/if}
+    </button>
+  {/each}
+</div>

--- a/static/fidget-svelte/App.svelte
+++ b/static/fidget-svelte/App.svelte
@@ -1,6 +1,6 @@
 <script>
   const gridSize = 4;
-  const counters = [];
+  let counters = [];
   const EXPIRING_SOON_MS = 30 * 24 * 60 * 60 * 1000;
 
   function format(ts) {
@@ -22,6 +22,7 @@
     } catch (e) {
       counter.error = e;
     }
+    counters = counters;
   }
 
   function createCounter(x, y) {
@@ -50,6 +51,7 @@
     } catch (e) {
       counter.error = e;
     }
+    counters = counters;
   }
 </script>
 
@@ -70,6 +72,10 @@
 .counter-button .count {
   display: block;
   font-size: 1.5em;
+}
+.error {
+  color: red;
+  font-size: 0.8em;
 }
 .payload {
   font-size: 0.8em;
@@ -102,6 +108,9 @@
             {/if}
           </tbody>
         </table>
+      {/if}
+      {#if counter.error}
+        <span class="error">{counter.error.message}</span>
       {/if}
     </button>
   {/each}

--- a/static/fidget-svelte/index.html
+++ b/static/fidget-svelte/index.html
@@ -6,20 +6,26 @@
 </head>
 <body>
   <div id="app"></div>
+  <pre id="error" style="color: red;"></pre>
   <script type="module">
-    import * as svelte from 'https://cdn.jsdelivr.net/npm/svelte@3.59.2';
     import { compile } from 'https://cdn.jsdelivr.net/npm/svelte@3.59.2/compiler.mjs';
-    window.svelte = svelte;
 
     async function main() {
-      const res = await fetch('App.svelte');
-      const source = await res.text();
-      const { js, css } = compile(source, { generate: 'dom', format: 'iife', name: 'App' });
-      const style = document.createElement('style');
-      style.textContent = css.code;
-      document.head.appendChild(style);
-      eval(js.code);
-      new App({ target: document.getElementById('app') });
+      try {
+        const res = await fetch('App.svelte');
+        if (!res.ok) throw new Error(`failed to load App.svelte: ${res.status}`);
+        const source = await res.text();
+        const { js, css } = compile(source, { generate: 'dom', format: 'iife', name: 'App' });
+        const style = document.createElement('style');
+        style.textContent = css.code;
+        document.head.appendChild(style);
+        const App = new Function(`${js.code}; return App;`)();
+        new App({ target: document.getElementById('app') });
+      } catch (err) {
+        const pre = document.getElementById('error');
+        pre.textContent = err.stack || err;
+        console.error(err);
+      }
     }
     main();
   </script>

--- a/static/fidget-svelte/index.html
+++ b/static/fidget-svelte/index.html
@@ -15,11 +15,21 @@
         const res = await fetch('App.svelte');
         if (!res.ok) throw new Error(`failed to load App.svelte: ${res.status}`);
         const source = await res.text();
-        const { js, css } = compile(source, { generate: 'dom', format: 'iife', name: 'App' });
-        const style = document.createElement('style');
-        style.textContent = css.code;
-        document.head.appendChild(style);
-        const App = new Function(`${js.code}; return App;`)();
+
+        const { js, css } = compile(source, { generate: 'dom', format: 'esm', name: 'App' });
+
+        if (css.code) {
+          const style = document.createElement('style');
+          style.textContent = css.code;
+          document.head.appendChild(style);
+        }
+
+        const runtimeUrl = 'https://cdn.jsdelivr.net/npm/svelte@3.59.2/internal/index.mjs';
+        const transformed = js.code.replace('from "svelte/internal"', `from '${runtimeUrl}'`);
+        const blob = new Blob([transformed], { type: 'application/javascript' });
+        const url = URL.createObjectURL(blob);
+        const { default: App } = await import(url);
+        URL.revokeObjectURL(url);
         new App({ target: document.getElementById('app') });
       } catch (err) {
         const pre = document.getElementById('error');

--- a/static/fidget-svelte/index.html
+++ b/static/fidget-svelte/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Tom Hummel :: Fidget Toy</title>
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module">
+    import * as svelte from 'https://cdn.jsdelivr.net/npm/svelte@3.59.2';
+    import { compile } from 'https://cdn.jsdelivr.net/npm/svelte@3.59.2/compiler.mjs';
+    window.svelte = svelte;
+
+    async function main() {
+      const res = await fetch('App.svelte');
+      const source = await res.text();
+      const { js, css } = compile(source, { generate: 'dom', format: 'iife', name: 'App' });
+      const style = document.createElement('style');
+      style.textContent = css.code;
+      document.head.appendChild(style);
+      eval(js.code);
+      new App({ target: document.getElementById('app') });
+    }
+    main();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- restore vanilla fidget toy page
- add Svelte-based version in separate directory
- link experiments page to both versions

## Testing
- `./.tool-versions-setup.sh`
- `./.asdf-local/bin/asdf exec hugo`


------
https://chatgpt.com/codex/tasks/task_e_68ad49408b2c8323b6fb1ea720520f35