### PR TITLE
Add card shuffling Svelte experiment

### DIFF
--- a/content/experiments.md
+++ b/content/experiments.md
@@ -9,3 +9,4 @@ date: 2020-09-01T08:00:00
 - [Fidget Toy v2](/fidget-v2)
 - [Pixel Wall](/pixel-wall-svelte)
 - [Borfin Shlump](/borfin-shlump)
+- [Card Shuffle](/card-shuffle-svelte)

--- a/static/card-shuffle-svelte/App.svelte
+++ b/static/card-shuffle-svelte/App.svelte
@@ -1,0 +1,42 @@
+<script>
+  const suits = ['\u2660', '\u2665', '\u2666', '\u2663']; // spades, hearts, diamonds, clubs
+  const ranks = ['A','2','3','4','5','6','7','8','9','10','J','Q','K'];
+  let deck = [];
+
+  function shuffle() {
+    deck = [];
+    for (const suit of suits) {
+      for (const rank of ranks) {
+        deck.push({ suit, rank });
+      }
+    }
+    for (let i = deck.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [deck[i], deck[j]] = [deck[j], deck[i]];
+    }
+  }
+</script>
+
+<style>
+  table {
+    border-collapse: collapse;
+    margin-top: 1em;
+  }
+  th, td {
+    border: 1px solid #ccc;
+    padding: 4px 8px;
+    text-align: left;
+  }
+</style>
+
+<button on:click={shuffle}>Shuffle</button>
+<table>
+  <thead>
+    <tr><th>#</th><th>Suit</th><th>Rank</th></tr>
+  </thead>
+  <tbody>
+    {#each deck as card, i}
+      <tr><td>{i + 1}</td><td>{card.suit}</td><td>{card.rank}</td></tr>
+    {/each}
+  </tbody>
+</table>

--- a/static/card-shuffle-svelte/App.svelte
+++ b/static/card-shuffle-svelte/App.svelte
@@ -3,17 +3,35 @@
   const ranks = ['A','2','3','4','5','6','7','8','9','10','J','Q','K'];
   let deck = [];
 
-  function shuffle() {
+  function initDeck() {
     deck = [];
     for (const suit of suits) {
       for (const rank of ranks) {
-        deck.push({ suit, rank });
+        deck.push({ suit, rank, prevIndex: undefined, movement: undefined });
       }
     }
+  }
+
+  function shuffle() {
+    if (deck.length === 0) {
+      initDeck();
+    }
+
+    const previousPositions = new Map();
+    deck.forEach((card, index) => {
+      previousPositions.set(card, index);
+    });
+
     for (let i = deck.length - 1; i > 0; i--) {
       const j = Math.floor(Math.random() * (i + 1));
       [deck[i], deck[j]] = [deck[j], deck[i]];
     }
+
+    deck.forEach((card, index) => {
+      const prevIndex = previousPositions.get(card);
+      card.prevIndex = prevIndex;
+      card.movement = prevIndex !== undefined ? prevIndex - index : undefined;
+    });
   }
 </script>
 
@@ -27,16 +45,36 @@
     padding: 4px 8px;
     text-align: left;
   }
+  .up { color: green; }
+  .down { color: red; }
 </style>
 
 <button on:click={shuffle}>Shuffle</button>
 <table>
   <thead>
-    <tr><th>#</th><th>Suit</th><th>Rank</th></tr>
+    <tr><th>#</th><th>Suit</th><th>Rank</th><th>Prev #</th><th>Δ</th></tr>
   </thead>
   <tbody>
     {#each deck as card, i}
-      <tr><td>{i + 1}</td><td>{card.suit}</td><td>{card.rank}</td></tr>
+      <tr>
+        <td>{i + 1}</td>
+        <td>{card.suit}</td>
+        <td>{card.rank}</td>
+        <td>{card.prevIndex !== undefined ? card.prevIndex + 1 : '-'}</td>
+        <td>
+          {#if card.prevIndex !== undefined}
+            {#if card.movement > 0}
+              <span class="up">↑{card.movement}</span>
+            {:else if card.movement < 0}
+              <span class="down">↓{Math.abs(card.movement)}</span>
+            {:else}
+              •
+            {/if}
+          {:else}
+            -
+          {/if}
+        </td>
+      </tr>
     {/each}
   </tbody>
 </table>

--- a/static/card-shuffle-svelte/index.html
+++ b/static/card-shuffle-svelte/index.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Tom Hummel :: Card Shuffle</title>
+  <script type="importmap">
+  {
+    "imports": {
+      "svelte/internal": "https://cdn.jsdelivr.net/npm/svelte@3.59.2/internal/index.mjs"
+    }
+  }
+  </script>
+</head>
+<body>
+  <div id="app"></div>
+  <script>
+    function log(msg) {
+      let pre = document.getElementById('log');
+      if (!pre) {
+        pre = document.createElement('pre');
+        pre.id = 'log';
+        pre.style.color = 'red';
+        pre.style.whiteSpace = 'pre-wrap';
+        document.body.appendChild(pre);
+      }
+      pre.textContent += (pre.textContent ? '\n' : '') + msg;
+    }
+
+    window.addEventListener('error', (e) => log(e.error?.stack || e.message));
+    window.addEventListener('unhandledrejection', (e) => log(e.reason?.stack || e.reason));
+  </script>
+  <script type="module">
+    import { compile } from 'https://cdn.jsdelivr.net/npm/svelte@3.59.2/compiler.mjs';
+
+    async function main() {
+      try {
+        const res = await fetch('App.svelte');
+        if (!res.ok) throw new Error(`failed to load App.svelte: ${res.status}`);
+        const source = await res.text();
+
+        const { js, css } = compile(source, { generate: 'dom', format: 'esm', name: 'App' });
+
+        if (css.code) {
+          const style = document.createElement('style');
+          style.textContent = css.code;
+          document.head.appendChild(style);
+        }
+
+        const { default: App } = await import(`data:text/javascript,${encodeURIComponent(js.code)}`);
+        new App({ target: document.getElementById('app') });
+      } catch (err) {
+        log(err.stack || err);
+        console.error(err);
+      }
+    }
+    main();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add Svelte-based card shuffling simulator with Fisher–Yates shuffle and table of shuffled cards.
- Link new experiment from the experiments index page.

## Testing
- `./.asdf-local/bin/asdf exec hugo`


------
https://chatgpt.com/codex/tasks/task_e_68bfa7291da48323b72510b7150b10ec