### PR TITLE
Add deterministic footer fleurons

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -16,5 +16,6 @@
 <main>
     {{ block "main" . }}{{ end }}
 </main>
+{{ partial "fleuron.html" . }}
 </body>
 </html>

--- a/layouts/partials/fleuron.html
+++ b/layouts/partials/fleuron.html
@@ -1,0 +1,57 @@
+{{- $path := .RelPermalink -}}
+{{- with .File -}}
+  {{- $path = .Path -}}
+{{- end -}}
+{{- $hash := md5 $path -}}
+{{- $hex := substr $hash 0 2 -}}
+{{- $digits := dict "0" 0 "1" 1 "2" 2 "3" 3 "4" 4 "5" 5 "6" 6 "7" 7 "8" 8 "9" 9 "a" 10 "b" 11 "c" 12 "d" 13 "e" 14 "f" 15 -}}
+{{- $first := substr $hex 0 1 -}}
+{{- $second := substr $hex 1 1 -}}
+{{- $value := add (mul (index $digits $first) 16) (index $digits $second) -}}
+{{- $fleurons := slice
+  `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40" width="80" height="40">
+      <path d="M24 30h32a9 9 0 0 0 0-18 13 13 0 0 0-24.5-3.4A7 7 0 0 0 24 30Z"
+            fill="none" stroke="black" stroke-width="2" stroke-linejoin="round"/>
+      <path d="M40 12v16M32 20h16M35 15l10 10M45 15l-10 10"
+            fill="none" stroke="black" stroke-width="1.8" stroke-linecap="round"/>
+    </svg>`
+  `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40" width="80" height="40">
+      <path d="M15 28c8-12 18-12 26 0-10 4-18 4-26 0Z"
+            fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+      <path d="M65 28c-8-12-18-12-26 0 10 4 18 4 26 0Z"
+            fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+      <circle cx="28" cy="18" r="2" fill="black"/>
+      <circle cx="40" cy="22" r="2" fill="black"/>
+      <circle cx="52" cy="18" r="2" fill="black"/>
+    </svg>`
+  `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40" width="80" height="40">
+      <path d="M6 26c9-10 21 10 34 0s23 10 34 0" fill="none"
+            stroke="black" stroke-width="2" stroke-linecap="round"/>
+      <path d="M40 6l4 9 10 1-7 6 3 10-10-6-10 6 3-10-7-6 10-1z"
+            fill="none" stroke="black" stroke-width="1.8" stroke-linejoin="round"/>
+    </svg>`
+  `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40" width="80" height="40">
+      <path d="M22 30h36c7 0 12-6 10-12-2-6-9-8-15-6a14 14 0 0 0-26-3A7 7 0 0 0 22 30Z"
+            fill="none" stroke="black" stroke-width="2" stroke-linejoin="round"/>
+      <path d="M8 34c8-6 18 6 28 0s20 6 28 0"
+            fill="none" stroke="black" stroke-width="2" stroke-linecap="round"/>
+      <circle cx="20" cy="20" r="1.6" fill="black"/>
+      <circle cx="40" cy="24" r="1.6" fill="black"/>
+      <circle cx="60" cy="20" r="1.6" fill="black"/>
+    </svg>`
+  `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40" width="80" height="40">
+      <path d="M18 30c-6-10-4-20 6-24 8-3 18 3 20 12-8-4-14-4-22 4Z"
+            fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+      <path d="M62 30c6-10 4-20-6-24-8-3-18 3-20 12 8-4 14-4 22 4Z"
+            fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+      <path d="M40 12v16M32 20h16"
+            fill="none" stroke="black" stroke-width="1.6" stroke-linecap="round"/>
+      <path d="M34 14l12 12M46 14l-12 12"
+            fill="none" stroke="black" stroke-width="1.6" stroke-linecap="round"/>
+    </svg>`
+-}}
+{{- $index := mod $value (len $fleurons) -}}
+{{- $fleuron := index $fleurons $index -}}
+<footer class="footer-fleuron" aria-hidden="true">
+  {{- $fleuron | safeHTML -}}
+</footer>

--- a/static/monospace-web/index.css
+++ b/static/monospace-web/index.css
@@ -437,6 +437,18 @@ label input {
 .grid:has(> :last-child:nth-child(8)) { --grid-cells: 8; }
 .grid:has(> :last-child:nth-child(9)) { --grid-cells: 9; }
 
+footer.footer-fleuron {
+  margin-top: calc(var(--line-height) * 3);
+  display: flex;
+  justify-content: center;
+}
+
+footer.footer-fleuron svg {
+  display: block;
+  width: 5rem;
+  height: auto;
+}
+
 /* DEBUG UTILITIES */
 
 .debug .debug-grid {


### PR DESCRIPTION
## Summary
- add a footer partial that selects from five SVG fleurons using a deterministic hash of each page path
- include the fleurons on every page footer and style them for consistent alignment

## Testing
- ./.asdf-local/bin/asdf exec hugo

------
https://chatgpt.com/codex/tasks/task_e_68c6c9adfd2883238db9ece920b6e643