### PR TITLE
Add Barcelona 2025 holidays pounce scoresheet

### DIFF
--- a/content/posts/2025-barcelona-holidays-pounce.md
+++ b/content/posts/2025-barcelona-holidays-pounce.md
@@ -1,6 +1,6 @@
 ---
 title: "2025 Barcelona Holidays Pounce"
-date: 2025-12-30T12:00:00-08:00
+date: 2025-12-30T08:00:00-08:00
 draft: true
 toc: false
 tags:

--- a/content/posts/2025-barcelona-holidays-pounce.md
+++ b/content/posts/2025-barcelona-holidays-pounce.md
@@ -1,0 +1,561 @@
+---
+title: "2025 Barcelona Holidays Pounce"
+date: 2025-12-30T12:00:00-08:00
+draft: true
+toc: false
+tags:
+  - pounce
+  - cards
+data:
+  sessions:
+    - session: "2025-12-25"
+      ruleset:
+        pile: 13
+        bonus: 5
+      hands:
+        - ts: "2025-12-25T22:36:00+01:00"
+          players:
+            - name: "nee"
+              score: 20
+              win: true
+            - name: "nancy"
+              score: 6
+            - name: "tom"
+              score: -15
+        - ts: "2025-12-25T22:50:00+01:00"
+          players:
+            - name: "nee"
+              score: 47
+              win: true
+            - name: "nancy"
+              score: 31
+            - name: "tom"
+              score: 21
+        - ts: "2025-12-25T22:56:00+01:00"
+          players:
+            - name: "nee"
+              score: 33
+              win: true
+            - name: "nancy"
+              score: 13
+            - name: "tom"
+              score: 19
+        - ts: "2025-12-25T23:01:00+01:00"
+          players:
+            - name: "nee"
+              score: 13
+            - name: "nancy"
+              score: -6
+            - name: "tom"
+              score: 20
+              win: true
+        - ts: "2025-12-25T23:09:00+01:00"
+          players:
+            - name: "nee"
+              score: -3
+            - name: "nancy"
+              score: 18
+              win: true
+            - name: "tom"
+              score: 12
+        - ts: "2025-12-25T23:14:00+01:00"
+          players:
+            - name: "nee"
+              score: 2
+            - name: "nancy"
+              score: -5
+            - name: "tom"
+              score: 14
+              win: true
+        - ts: "2025-12-25T23:20:00+01:00"
+          players:
+            - name: "nee"
+              score: 34
+              win: true
+            - name: "nancy"
+              score: 5
+            - name: "tom"
+              score: 14
+        - ts: "2025-12-25T23:30:00+01:00"
+          players:
+            - name: "nee"
+              score: 8
+            - name: "nancy"
+              score: -2
+            - name: "tom"
+              score: 25
+              win: true
+    - session: "2025-12-27"
+      ruleset:
+        pile: 13
+        bonus: 5
+      hands:
+        - ts: "2025-12-27T15:45:00+01:00"
+          players:
+            - name: "wyatt"
+              score: -5
+            - name: "sadie"
+              score: -15
+            - name: "alissa"
+              score: 23
+              win: true
+            - name: "caitlin"
+              score: -15
+            - name: "tom"
+              score: -19
+        - ts: "2025-12-27T15:53:00+01:00"
+          players:
+            - name: "wyatt"
+              score: 3
+            - name: "sadie"
+              score: -7
+            - name: "alissa"
+              score: 5
+            - name: "caitlin"
+              score: -3
+            - name: "tom"
+              score: 25
+              win: true
+        - ts: "2025-12-27T16:00:00+01:00"
+          players:
+            - name: "wyatt"
+              score: 6
+            - name: "sadie"
+              score: -10
+            - name: "alissa"
+              score: 0
+            - name: "caitlin"
+              score: -9
+            - name: "tom"
+              score: 26
+              win: true
+        - ts: "2025-12-27T16:04:00+01:00"
+          players:
+            - name: "wyatt"
+              score: -9
+            - name: "sadie"
+              score: -8
+            - name: "alissa"
+              score: -2
+            - name: "caitlin"
+              score: -12
+            - name: "tom"
+              score: 20
+              win: true
+        - ts: "2025-12-27T16:17:00+01:00"
+          players:
+            - name: "sadie"
+              score: -12
+            - name: "alissa"
+              score: 19
+            - name: "caitlin"
+              score: -11
+            - name: "tom"
+              score: 24
+              win: true
+            - name: "nee"
+              score: 15
+        - ts: "2025-12-27T16:20:00+01:00"
+          players:
+            - name: "sadie"
+              score: -5
+            - name: "alissa"
+              score: 14
+              win: true
+            - name: "caitlin"
+              score: -15
+            - name: "tom"
+              score: 2
+            - name: "nee"
+              score: 6
+        - ts: "2025-12-27T16:26:00+01:00"
+          players:
+            - name: "sadie"
+              score: -12
+            - name: "alissa"
+              score: -14
+            - name: "caitlin"
+              score: 6
+            - name: "tom"
+              score: 5
+            - name: "nee"
+              score: 23
+              win: true
+        - ts: "2025-12-27T16:33:00+01:00"
+          players:
+            - name: "sadie"
+              score: 9
+            - name: "alissa"
+              score: 1
+            - name: "caitlin"
+              score: -7
+            - name: "tom"
+              score: 18
+              win: true
+            - name: "nee"
+              score: 11
+        - ts: "2025-12-27T16:40:00+01:00"
+          players:
+            - name: "sadie"
+              score: 14
+            - name: "alissa"
+              score: -7
+            - name: "tom"
+              score: 5
+            - name: "nee"
+              score: 36
+              win: true
+        - ts: "2025-12-27T16:45:00+01:00"
+          players:
+            - name: "sadie"
+              score: 8
+            - name: "alissa"
+              score: -5
+            - name: "tom"
+              score: 19
+              win: true
+            - name: "nee"
+              score: 0
+    - session: "2025-12-28"
+      ruleset:
+        pile: 13
+        bonus: 5
+      hands:
+        - ts: "2025-12-28T22:47:00+01:00"
+          players:
+            - name: "tom"
+              score: -4
+            - name: "sadie"
+              score: 12
+            - name: "alissa"
+              score: 3
+            - name: "nee"
+              score: 25
+              win: true
+        - ts: "2025-12-28T22:56:00+01:00"
+          players:
+            - name: "tom"
+              score: 17
+              win: true
+            - name: "sadie"
+              score: -5
+            - name: "alissa"
+              score: 5
+            - name: "nee"
+              score: -1
+        - ts: "2025-12-28T22:59:00+01:00"
+          players:
+            - name: "tom"
+              score: 17
+              win: true
+            - name: "sadie"
+              score: 10
+            - name: "alissa"
+              score: 5
+            - name: "nee"
+              score: -16
+        - ts: "2025-12-28T23:07:00+01:00"
+          players:
+            - name: "tom"
+              score: 4
+            - name: "sadie"
+              score: 4
+            - name: "alissa"
+              score: 6
+            - name: "nee"
+              score: 28
+              win: true
+        - ts: "2025-12-28T23:14:00+01:00"
+          players:
+            - name: "tom"
+              score: 21
+              win: true
+            - name: "sadie"
+              score: -6
+            - name: "alissa"
+              score: -9
+            - name: "nee"
+              score: 5
+        - ts: "2025-12-28T23:26:00+01:00"
+          players:
+            - name: "tom"
+              score: 15
+            - name: "sadie"
+              score: 34
+              win: true
+            - name: "alissa"
+              score: 0
+            - name: "nee"
+              score: 31
+    - session: "2025-12-29"
+      ruleset:
+        pile: 13
+        bonus: 5
+      hands:
+        - ts: "2025-12-29T23:10:00+01:00"
+          players:
+            - name: "wyatt"
+              score: 4
+            - name: "gavin"
+              score: -6
+            - name: "nancy"
+              score: -9
+            - name: "nee"
+              score: -9
+            - name: "tom"
+              score: 18
+              win: true
+        - ts: "2025-12-29T23:15:00+01:00"
+          players:
+            - name: "wyatt"
+              score: -6
+            - name: "gavin"
+              score: 19
+              win: true
+            - name: "nancy"
+              score: 8
+            - name: "nee"
+              score: 8
+            - name: "tom"
+              score: 16
+        - ts: "2025-12-29T23:20:00+01:00"
+          players:
+            - name: "wyatt"
+              score: 1
+            - name: "gavin"
+              score: -15
+            - name: "nancy"
+              score: -4
+            - name: "nee"
+              score: 28
+              win: true
+            - name: "tom"
+              score: -9
+        - ts: "2025-12-29T23:25:00+01:00"
+          players:
+            - name: "wyatt"
+              score: -12
+            - name: "gavin"
+              score: -10
+            - name: "nancy"
+              score: -8
+            - name: "nee"
+              score: 14
+              win: true
+            - name: "tom"
+              score: -17
+        - ts: "2025-12-29T23:30:00+01:00"
+          players:
+            - name: "wyatt"
+              score: 8
+            - name: "gavin"
+              score: 7
+            - name: "nancy"
+              score: -1
+            - name: "nee"
+              score: 31
+              win: true
+            - name: "tom"
+              score: 4
+        - ts: "2025-12-29T23:34:00+01:00"
+          players:
+            - name: "wyatt"
+              score: 11
+            - name: "gavin"
+              score: 13
+            - name: "nancy"
+              score: 21
+              win: true
+            - name: "nee"
+              score: 20
+            - name: "tom"
+              score: -6
+        - ts: "2025-12-29T23:40:00+01:00"
+          players:
+            - name: "wyatt"
+              score: 6
+            - name: "gavin"
+              score: -4
+            - name: "nancy"
+              score: 24
+              win: true
+            - name: "nee"
+              score: 0
+            - name: "tom"
+              score: -8
+        - ts: "2025-12-29T23:45:00+01:00"
+          players:
+            - name: "wyatt"
+              score: -17
+            - name: "gavin"
+              score: -13
+            - name: "nancy"
+              score: -19
+            - name: "nee"
+              score: 11
+              win: true
+            - name: "tom"
+              score: -4
+        - ts: "2025-12-29T23:48:00+01:00"
+          note: "tom's big arm"
+          players:
+            - name: "wyatt"
+              score: 2
+            - name: "gavin"
+              score: 1
+            - name: "nancy"
+              score: -5
+            - name: "nee"
+              score: 14
+            - name: "tom"
+              score: 17
+              win: true
+        - ts: "2025-12-29T23:53:00+01:00"
+          players:
+            - name: "wyatt"
+              score: 1
+            - name: "gavin"
+              score: -10
+            - name: "nancy"
+              score: 23
+              win: true
+            - name: "nee"
+              score: 10
+            - name: "tom"
+              score: 10
+        - ts: "2025-12-29T23:58:00+01:00"
+          players:
+            - name: "wyatt"
+              score: 14
+            - name: "gavin"
+              score: 9
+            - name: "nancy"
+              score: 16
+              win: true
+            - name: "nee"
+              score: 2
+            - name: "tom"
+              score: 11
+        - ts: "2025-12-30T00:03:00+01:00"
+          players:
+            - name: "wyatt"
+              score: -21
+            - name: "gavin"
+              score: -11
+            - name: "nancy"
+              score: 0
+            - name: "nee"
+              score: 18
+              win: true
+            - name: "tom"
+              score: -13
+---
+
+{{< pounce.inline >}}
+{{ $sessions := .Page.Params.data.sessions }}
+<p>Sessions: {{ len $sessions }}</p>
+
+<table>
+  <tr>
+    <th>#</th>
+    <th>Start</th>
+    <th>End</th>
+    <th>Hands</th>
+    <th>Players</th>
+    <th>Player-Hands</th>
+    <th>Rules</th>
+  </tr>
+
+  {{ range $i, $session := sort $sessions "session" }}
+    {{ $distinctPlayers := dict }}
+    {{ $handPlayerCount := 0 }}
+    {{ $startTs := time "2199-01-01T16:35:00-0700" }}
+    {{ $endTs := time "1899-01-01T16:35:00-0700" }}
+
+    {{ range $hand := $session.hands }}
+      {{ $handPlayerCount = add $handPlayerCount (len $hand.players) }}
+      {{ $handTs := time $hand.ts }}
+      {{ if lt $handTs $startTs }}
+        {{ $startTs = $handTs }}
+      {{ end }}
+      {{ if gt $handTs $endTs }}
+        {{ $endTs = $handTs }}
+      {{ end }}
+
+      {{ range $handPlayer := $hand.players }}
+        {{ $distinctPlayers = merge $distinctPlayers (dict $handPlayer.name true) }}
+      {{ end }}
+    {{ end }}
+
+    <tr>
+      <td>{{ add $i 1 }}</td>
+      <td>{{ $startTs | time.Format "01/02 15:04" }}</td>
+      <td>{{ $endTs | time.Format "01/02 15:04"  }}</td>
+      <td>{{ len $session.hands }}</td>
+      <td>{{ len $distinctPlayers }}</td>
+      <td>{{ $handPlayerCount }}</td>
+      <td>{{ $session.ruleset.pile }}+{{ $session.ruleset.bonus }}</td>
+    </tr>
+  {{ end }}
+
+</table>
+
+{{ $allHands := slice }}
+{{ range $session := $sessions }}
+  {{ range $hand := $session.hands }}
+    {{ $hand = merge $hand (dict "ruleset" $session.ruleset) }}
+    {{ $allHands = $allHands | append $hand }}
+  {{ end }}
+{{ end }}
+
+<p>Hands: {{ len $allHands }}</p>
+
+{{ $perPlayer := dict "handCount" 0 "winCount" 0 "scoreSum" 0 }}
+{{ $scoreboardByPlayer := dict }}
+
+{{ range $hand := $allHands }}
+  {{ $ruleset := $hand.ruleset }}
+  {{ range $handPlayer := $hand.players }}
+    {{ if not (isset $scoreboardByPlayer $handPlayer.name) }}
+      {{ $scoreboardByPlayer = merge $scoreboardByPlayer (dict $handPlayer.name $perPlayer)}}
+    {{ end }}
+
+    {{ $before := index $scoreboardByPlayer $handPlayer.name }}
+    {{ $handPlayerScore := add $handPlayer.score (cond ($handPlayer.win | default false) $ruleset.bonus 0) }}
+
+    {{ $after := merge $before (dict "handCount" (add (index $before "handCount") 1) "winCount" (add (index $before "winCount") (cond ($handPlayer.win | default false) 1 0)) "scoreSum" (add (index $before "scoreSum") $handPlayerScore) ) }}
+    {{ $scoreboardByPlayer = merge $scoreboardByPlayer (dict $handPlayer.name $after) }}
+  {{ end }}
+{{ end }}
+
+<table>
+  <tr>
+    <th>Rank</th>
+    <th>Name</th>
+    <th>Score Avg ↓</th>
+    <th>Wins</th>
+  </tr>
+
+  {{ $sortable := slice }}
+  {{ range $name, $stats := $scoreboardByPlayer }}
+    {{ $scoreAvg := div $stats.scoreSum (float $stats.handCount) }}
+    {{ $winAvg := div $stats.winCount (float $stats.handCount) }}
+    {{ $row := merge $stats (dict "name" $name "scoreAvg" $scoreAvg "winAvg" $winAvg) }}
+    {{ $sortable = append $sortable (slice $row)}}
+  {{ end }}
+
+  {{ range $i, $row := sort $sortable "scoreAvg" "desc" }}
+    <tr>
+      <td>{{ add $i 1 }}</td>
+      <td>{{ .name | title }}</td>
+      <td>
+        {{ lang.FormatNumber 3 .scoreAvg }} ({{ .scoreSum }} / {{ .handCount }})
+      </td>
+      <td>
+        {{ .winCount }}
+      </td>
+    </tr>
+  {{ end }}
+</table>
+
+{{< /pounce.inline >}}


### PR DESCRIPTION
Digitizes 4 pounce sessions from Barcelona holiday trip (Dec 25-29, 2025) with 36 total hands across 9 players.

🤖 Generated with [Claude Code](https://claude.com/claude-code)