### PR TITLE
Add craps simulator to lab/experiments

### DIFF
--- a/content/experiments.md
+++ b/content/experiments.md
@@ -10,3 +10,4 @@ date: 2020-09-01T08:00:00
 - [Pixel Wall](/pixel-wall-svelte)
 - [Borfin Shlump](/borfin-shlump)
 - [Card Shuffle](/card-shuffle-svelte)
+- [Craps Simulator](/craps)

--- a/static/craps/App.svelte
+++ b/static/craps/App.svelte
@@ -25,8 +25,16 @@
   const maxOddsMultiple = { 4: 3, 5: 4, 6: 5, 8: 5, 9: 4, 10: 3 };
 
   let results = null;
-  let lastHistory = null;
-  let showHistory = false;
+  let allHistories = [];
+
+  $: detailHands = results
+    ? (results.hands <= 10
+        ? allHistories
+        : [
+            ...allHistories.slice().sort((a, b) => b.balance - a.balance).slice(0, 5),
+            ...allHistories.slice().sort((a, b) => a.balance - b.balance).slice(0, 5)
+          ].sort((a, b) => a.index - b.index))
+    : [];
 
   const resultLabels = {
     'comeout win':  'Come-out Win',
@@ -54,6 +62,7 @@
     const rules = buildRules();
     const bettingStrategy = craps.betting[strategyName];
     const handResults = [];
+    allHistories = [];
     let wins = 0;
     let losses = 0;
     let totalWagered = 0;
@@ -69,7 +78,7 @@
       totalReturned += gained;
       if (balance >= 0) wins++; else losses++;
       handResults.push({ rolls: history.length, balance });
-      if (i === numHands - 1) lastHistory = history;
+      allHistories.push({ index: i, balance, history });
     }
 
     const avgBalance = handResults.reduce((s, r) => s + r.balance, 0) / numHands;
@@ -120,8 +129,10 @@
   th { background: #f5f5f5; font-size: 0.8rem; }
   .roll-result { font-weight: bold; }
   .tag { display: inline-block; font-size: 0.75rem; padding: 1px 6px; border-radius: 3px; color: #fff; margin-right: 3px; }
-  .toggle { background: none; color: #333; border: 1px solid #ccc; margin-top: 0.5rem; font-size: 0.85rem; padding: 0.3rem 0.8rem; }
   .hand-chart { display: flex; flex-wrap: wrap; gap: 4px; margin: 0.5rem 0; }
+  details { border: 1px solid #ddd; border-radius: 4px; margin-bottom: 0.5rem; }
+  details summary { padding: 0.5rem 0.75rem; cursor: pointer; font-size: 0.9rem; }
+  details[open] summary { border-bottom: 1px solid #ddd; }
   .hand-dot { width: 14px; height: 14px; border-radius: 2px; }
   .hist-wrap { overflow-x: auto; }
   .error { color: #dc2626; font-family: monospace; }
@@ -200,19 +211,17 @@
       {/each}
     </div>
 
-    {#if lastHistory}
-      <button class="toggle" on:click={() => showHistory = !showHistory}>
-        {showHistory ? 'Hide' : 'Show'} Last Hand Roll-by-Roll
-      </button>
-
-      {#if showHistory}
+    <h2>Hand Detail{results.hands > 10 ? ' — 5 Best & 5 Worst' : ''}</h2>
+    {#each detailHands as hand}
+      <details>
+        <summary>Hand {hand.index + 1} — {fmt(hand.balance)} ({hand.history.length} rolls)</summary>
         <div class="hist-wrap">
           <table>
             <thead>
               <tr><th>#</th><th>Dice</th><th>Sum</th><th>Result</th><th>Point</th><th>Payouts</th></tr>
             </thead>
             <tbody>
-              {#each lastHistory as roll, i}
+              {#each hand.history as roll, i}
                 <tr>
                   <td>{i + 1}</td>
                   <td>{roll.die1} + {roll.die2}</td>
@@ -239,7 +248,7 @@
             </tbody>
           </table>
         </div>
-      {/if}
-    {/if}
+      </details>
+    {/each}
   {/if}
 {/if}

--- a/static/craps/App.svelte
+++ b/static/craps/App.svelte
@@ -96,7 +96,6 @@
       maxBalance,
       handResults
     };
-    showHistory = false;
   }
 
   function fmt(n) {

--- a/static/craps/App.svelte
+++ b/static/craps/App.svelte
@@ -25,7 +25,7 @@
   let strategyName = 'Pass Line Only';
   let numSessions = 50;
   let minBet = 5;
-  let maxOdds = '3-4-5';
+  const maxOddsMultiple = { 4: 3, 5: 4, 6: 5, 8: 5, 9: 4, 10: 3 };
 
   let results = null;
   let lastHistory = null;
@@ -49,18 +49,8 @@
     'neutral':      '#888'
   };
 
-  function parseOdds(str) {
-    const parts = String(str).split('-').map(n => parseInt(n, 10));
-    if (parts.length !== 3 || parts.some(n => isNaN(n))) return null;
-    return { 4: parts[0], 5: parts[1], 6: parts[2], 8: parts[2], 9: parts[1], 10: parts[0] };
-  }
-
   function buildRules() {
-    return {
-      ...craps.defaultRules,
-      minBet,
-      maxOddsMultiple: parseOdds(maxOdds)
-    };
+    return { ...craps.defaultRules, minBet, maxOddsMultiple };
   }
 
   function simulate() {
@@ -162,12 +152,8 @@
       <label for="minbet">Min Bet ($)</label>
       <input id="minbet" type="number" min="1" max="500" bind:value={minBet} style="width:80px" />
     </div>
-    <div class="field">
-      <label for="maxodds">Max Odds</label>
-      <input id="maxodds" type="text" placeholder="3-4-5" bind:value={maxOdds} style="width:80px" />
-    </div>
     <div class="field" style="justify-content:flex-end">
-      <button on:click={simulate} disabled={!craps || !parseOdds(maxOdds)}>
+      <button on:click={simulate} disabled={!craps}>
         {craps ? 'Simulate' : 'Loading…'}
       </button>
     </div>

--- a/static/craps/App.svelte
+++ b/static/craps/App.svelte
@@ -1,10 +1,18 @@
 <script>
+  import { onMount } from 'svelte';
+
   const MODULE_URL = 'https://esm.sh/gh/tphummel/node-craps';
 
   let craps = null;
   let loadError = null;
 
-  import(MODULE_URL).then(m => { craps = m; }).catch(err => { loadError = err.message; });
+  onMount(async () => {
+    try {
+      craps = await import(MODULE_URL);
+    } catch (err) {
+      loadError = err.message;
+    }
+  });
 
   const strategyKeys = {
     'Pass Line Only':              'minPassLineOnly',

--- a/static/craps/App.svelte
+++ b/static/craps/App.svelte
@@ -23,7 +23,7 @@
   };
 
   let strategyName = 'Pass Line Only';
-  let numSessions = 50;
+  let numHands = 50;
   let minBet = 5;
   const maxOddsMultiple = { 4: 3, 5: 4, 6: 5, 8: 5, 9: 4, 10: 3 };
 
@@ -56,13 +56,13 @@
   function simulate() {
     const rules = buildRules();
     const bettingStrategy = craps.betting[strategyKeys[strategyName]];
-    const sessionResults = [];
+    const handResults = [];
     let wins = 0;
     let losses = 0;
     let totalWagered = 0;
     let totalReturned = 0;
 
-    for (let i = 0; i < numSessions; i++) {
+    for (let i = 0; i < numHands; i++) {
       const { history, balance } = craps.playHand({ rules, bettingStrategy });
 
       const gained = history.reduce((sum, roll) => {
@@ -71,24 +71,24 @@
 
       totalReturned += gained;
       if (balance >= 0) wins++; else losses++;
-      sessionResults.push({ rolls: history.length, balance });
-      if (i === numSessions - 1) lastHistory = history;
+      handResults.push({ rolls: history.length, balance });
+      if (i === numHands - 1) lastHistory = history;
     }
 
-    const avgBalance = sessionResults.reduce((s, r) => s + r.balance, 0) / numSessions;
-    const avgRolls   = sessionResults.reduce((s, r) => s + r.rolls,   0) / numSessions;
-    const minBalance = Math.min(...sessionResults.map(r => r.balance));
-    const maxBalance = Math.max(...sessionResults.map(r => r.balance));
+    const avgBalance = handResults.reduce((s, r) => s + r.balance, 0) / numHands;
+    const avgRolls   = handResults.reduce((s, r) => s + r.rolls,   0) / numHands;
+    const minBalance = Math.min(...handResults.map(r => r.balance));
+    const maxBalance = Math.max(...handResults.map(r => r.balance));
 
     results = {
-      sessions: numSessions,
+      hands: numHands,
       wins,
       losses,
       avgBalance: avgBalance.toFixed(2),
       avgRolls:   avgRolls.toFixed(1),
       minBalance,
       maxBalance,
-      sessionResults
+      handResults
     };
     showHistory = false;
   }
@@ -123,14 +123,14 @@
   .roll-result { font-weight: bold; }
   .tag { display: inline-block; font-size: 0.75rem; padding: 1px 6px; border-radius: 3px; color: #fff; margin-right: 3px; }
   .toggle { background: none; color: #333; border: 1px solid #ccc; margin-top: 0.5rem; font-size: 0.85rem; padding: 0.3rem 0.8rem; }
-  .session-chart { display: flex; flex-wrap: wrap; gap: 4px; margin: 0.5rem 0; }
-  .session-dot { width: 14px; height: 14px; border-radius: 2px; }
+  .hand-chart { display: flex; flex-wrap: wrap; gap: 4px; margin: 0.5rem 0; }
+  .hand-dot { width: 14px; height: 14px; border-radius: 2px; }
   .hist-wrap { overflow-x: auto; }
   .error { color: #dc2626; font-family: monospace; }
 </style>
 
 <h1>Craps Simulator</h1>
-<p>Simulate craps sessions using betting strategies from <a href="https://github.com/tphummel/node-craps" target="_blank">node-craps</a>.</p>
+<p>Simulate craps hands using betting strategies from <a href="https://github.com/tphummel/node-craps" target="_blank">node-craps</a>.</p>
 
 {#if loadError}
   <p class="error">Failed to load module: {loadError}</p>
@@ -145,8 +145,8 @@
       </select>
     </div>
     <div class="field">
-      <label for="sessions">Sessions</label>
-      <input id="sessions" type="number" min="1" max="10000" bind:value={numSessions} style="width:100px" />
+      <label for="hands">Hands</label>
+      <input id="hands" type="number" min="1" max="10000" bind:value={numHands} style="width:100px" />
     </div>
     <div class="field">
       <label for="minbet">Min Bet ($)</label>
@@ -160,48 +160,48 @@
   </div>
 
   {#if results}
-    <h2>Results — {results.sessions} sessions</h2>
+    <h2>Results — {results.hands} hands</h2>
     <div class="stats-grid">
       <div class="stat">
-        <div class="stat-label">Avg Net / Session</div>
+        <div class="stat-label">Avg Net / Hand</div>
         <div class="stat-value {Number(results.avgBalance) >= 0 ? 'positive' : 'negative'}">{fmt(results.avgBalance)}</div>
       </div>
       <div class="stat">
-        <div class="stat-label">Win / Loss Sessions</div>
+        <div class="stat-label">Win / Loss Hands</div>
         <div class="stat-value neutral-color">{results.wins} / {results.losses}</div>
       </div>
       <div class="stat">
         <div class="stat-label">Win Rate</div>
-        <div class="stat-value neutral-color">{(results.wins / results.sessions * 100).toFixed(1)}%</div>
+        <div class="stat-value neutral-color">{(results.wins / results.hands * 100).toFixed(1)}%</div>
       </div>
       <div class="stat">
-        <div class="stat-label">Avg Rolls / Session</div>
+        <div class="stat-label">Avg Rolls / Hand</div>
         <div class="stat-value neutral-color">{results.avgRolls}</div>
       </div>
       <div class="stat">
-        <div class="stat-label">Best Session</div>
+        <div class="stat-label">Best Hand</div>
         <div class="stat-value positive">{fmt(results.maxBalance)}</div>
       </div>
       <div class="stat">
-        <div class="stat-label">Worst Session</div>
+        <div class="stat-label">Worst Hand</div>
         <div class="stat-value negative">{fmt(results.minBalance)}</div>
       </div>
     </div>
 
-    <h2>Session Results</h2>
-    <div class="session-chart">
-      {#each results.sessionResults as s, i}
+    <h2>Hand Results</h2>
+    <div class="hand-chart">
+      {#each results.handResults as s, i}
         <div
-          class="session-dot"
+          class="hand-dot"
           style="background:{s.balance >= 0 ? '#22c55e' : '#ef4444'}"
-          title="Session {i+1}: {fmt(s.balance)} ({s.rolls} rolls)"
+          title="Hand {i+1}: {fmt(s.balance)} ({s.rolls} rolls)"
         ></div>
       {/each}
     </div>
 
     {#if lastHistory}
       <button class="toggle" on:click={() => showHistory = !showHistory}>
-        {showHistory ? 'Hide' : 'Show'} Last Session Roll-by-Roll
+        {showHistory ? 'Hide' : 'Show'} Last Hand Roll-by-Roll
       </button>
 
       {#if showHistory}

--- a/static/craps/App.svelte
+++ b/static/craps/App.svelte
@@ -9,35 +9,17 @@
   onMount(async () => {
     try {
       craps = await import(MODULE_URL);
+      strategyName = availableStrategies[0][0];
     } catch (err) {
       loadError = err.message;
     }
   });
 
-  const strategies = {
-    'Pass Line Only': {
-      key: 'minPassLineOnly',
-      description: 'Bet the minimum on the pass line each come-out roll. No odds, no additional bets. The simplest possible strategy.'
-    },
-    'Pass + Max Odds': {
-      key: 'minPassLineMaxOdds',
-      description: 'Bet the minimum on the pass line, then back it with full 3-4-5x odds once a point is set. Odds bets carry no house edge.'
-    },
-    'Pass + Place 6/8': {
-      key: 'minPassLinePlaceSixEight',
-      description: 'Bet the minimum on the pass line, plus place bets on 6 and 8 after a point is set (skipping whichever is the point).'
-    },
-    'Pass + Max Odds + Place 6/8': {
-      key: 'minPassLineMaxOddsPlaceSixEight',
-      description: 'Bet the minimum on the pass line with full 3-4-5x odds, plus place bets on 6 and 8 (skipping the point).'
-    },
-    'Pass + Come + Place 6/8': {
-      key: 'passCome68',
-      description: 'Pass line with full odds, one come bet with full odds, and place bets on 6 and 8. Avoids redundant coverage when the come bet lands on 6 or 8.'
-    },
-  };
+  $: availableStrategies = craps
+    ? Object.entries(craps.betting).filter(([key, fn]) => fn.title && key !== 'lineMaxOdds')
+    : [];
 
-  let strategyName = 'Pass Line Only';
+  let strategyName = null;
   let numHands = 50;
   let minBet = 5;
   const maxOddsMultiple = { 4: 3, 5: 4, 6: 5, 8: 5, 9: 4, 10: 3 };
@@ -70,7 +52,7 @@
 
   function simulate() {
     const rules = buildRules();
-    const bettingStrategy = craps.betting[strategies[strategyName].key];
+    const bettingStrategy = craps.betting[strategyName];
     const handResults = [];
     let wins = 0;
     let losses = 0;
@@ -154,13 +136,15 @@
   <div class="controls">
     <div class="field">
       <label for="strategy">Betting Strategy</label>
-      <select id="strategy" bind:value={strategyName}>
-        {#each Object.keys(strategies) as s}
-          <option value={s}>{s}</option>
+      <select id="strategy" bind:value={strategyName} disabled={!craps}>
+        {#each availableStrategies as [key, fn]}
+          <option value={key}>{fn.title}</option>
         {/each}
       </select>
     </div>
-    <div class="strategy-desc">{strategies[strategyName].description}</div>
+    {#if strategyName}
+      <div class="strategy-desc">{craps.betting[strategyName].description}</div>
+    {/if}
     <div class="field">
       <label for="hands">Hands</label>
       <input id="hands" type="number" min="1" max="10000" bind:value={numHands} style="width:100px" />

--- a/static/craps/App.svelte
+++ b/static/craps/App.svelte
@@ -1,18 +1,10 @@
 <script>
-  import { onMount } from 'svelte';
-
   const MODULE_URL = 'https://esm.sh/gh/tphummel/node-craps';
 
   let craps = null;
   let loadError = null;
 
-  onMount(async () => {
-    try {
-      craps = await import(MODULE_URL);
-    } catch (err) {
-      loadError = err.message;
-    }
-  });
+  import(MODULE_URL).then(m => { craps = m; }).catch(err => { loadError = err.message; });
 
   const strategyKeys = {
     'Pass Line Only':              'minPassLineOnly',

--- a/static/craps/App.svelte
+++ b/static/craps/App.svelte
@@ -9,7 +9,6 @@
   onMount(async () => {
     try {
       craps = await import(MODULE_URL);
-      strategyName = availableStrategies[0][0];
     } catch (err) {
       loadError = err.message;
     }
@@ -20,6 +19,7 @@
     : [];
 
   let strategyName = null;
+  $: if (availableStrategies.length && !strategyName) strategyName = availableStrategies[0][0];
   let numHands = 50;
   let minBet = 5;
   const maxOddsMultiple = { 4: 3, 5: 4, 6: 5, 8: 5, 9: 4, 10: 3 };

--- a/static/craps/App.svelte
+++ b/static/craps/App.svelte
@@ -25,7 +25,7 @@
   let strategyName = 'Pass Line Only';
   let numSessions = 50;
   let minBet = 5;
-  let maxOdds = 3;
+  let maxOdds = '3-4-5';
 
   let results = null;
   let lastHistory = null;
@@ -49,11 +49,17 @@
     'neutral':      '#888'
   };
 
+  function parseOdds(str) {
+    const parts = String(str).split('-').map(n => parseInt(n, 10));
+    if (parts.length !== 3 || parts.some(n => isNaN(n))) return null;
+    return { 4: parts[0], 5: parts[1], 6: parts[2], 8: parts[2], 9: parts[1], 10: parts[0] };
+  }
+
   function buildRules() {
     return {
       ...craps.defaultRules,
       minBet,
-      maxOddsMultiple: { 4: maxOdds, 5: maxOdds, 6: maxOdds, 8: maxOdds, 9: maxOdds, 10: maxOdds }
+      maxOddsMultiple: parseOdds(maxOdds)
     };
   }
 
@@ -157,11 +163,11 @@
       <input id="minbet" type="number" min="1" max="500" bind:value={minBet} style="width:80px" />
     </div>
     <div class="field">
-      <label for="maxodds">Max Odds (×)</label>
-      <input id="maxodds" type="number" min="0" max="100" bind:value={maxOdds} style="width:80px" />
+      <label for="maxodds">Max Odds</label>
+      <input id="maxodds" type="text" placeholder="3-4-5" bind:value={maxOdds} style="width:80px" />
     </div>
     <div class="field" style="justify-content:flex-end">
-      <button on:click={simulate} disabled={!craps}>
+      <button on:click={simulate} disabled={!craps || !parseOdds(maxOdds)}>
         {craps ? 'Simulate' : 'Loading…'}
       </button>
     </div>

--- a/static/craps/App.svelte
+++ b/static/craps/App.svelte
@@ -14,12 +14,27 @@
     }
   });
 
-  const strategyKeys = {
-    'Pass Line Only':              'minPassLineOnly',
-    'Pass + Max Odds':             'minPassLineMaxOdds',
-    'Pass + Place 6/8':            'minPassLinePlaceSixEight',
-    'Pass + Max Odds + Place 6/8': 'minPassLineMaxOddsPlaceSixEight',
-    'Pass + Come + Place 6/8':     'passCome68',
+  const strategies = {
+    'Pass Line Only': {
+      key: 'minPassLineOnly',
+      description: 'Bet the minimum on the pass line each come-out roll. No odds, no additional bets. The simplest possible strategy.'
+    },
+    'Pass + Max Odds': {
+      key: 'minPassLineMaxOdds',
+      description: 'Bet the minimum on the pass line, then back it with full 3-4-5x odds once a point is set. Odds bets carry no house edge.'
+    },
+    'Pass + Place 6/8': {
+      key: 'minPassLinePlaceSixEight',
+      description: 'Bet the minimum on the pass line, plus place bets on 6 and 8 after a point is set (skipping whichever is the point).'
+    },
+    'Pass + Max Odds + Place 6/8': {
+      key: 'minPassLineMaxOddsPlaceSixEight',
+      description: 'Bet the minimum on the pass line with full 3-4-5x odds, plus place bets on 6 and 8 (skipping the point).'
+    },
+    'Pass + Come + Place 6/8': {
+      key: 'passCome68',
+      description: 'Pass line with full odds, one come bet with full odds, and place bets on 6 and 8. Avoids redundant coverage when the come bet lands on 6 or 8.'
+    },
   };
 
   let strategyName = 'Pass Line Only';
@@ -55,7 +70,7 @@
 
   function simulate() {
     const rules = buildRules();
-    const bettingStrategy = craps.betting[strategyKeys[strategyName]];
+    const bettingStrategy = craps.betting[strategies[strategyName].key];
     const handResults = [];
     let wins = 0;
     let losses = 0;
@@ -103,7 +118,8 @@
   * { box-sizing: border-box; }
   h1 { margin: 0 0 1rem 0; font-size: 1.4rem; }
   h2 { font-size: 1.1rem; margin: 1.2rem 0 0.5rem 0; }
-  .controls { display: flex; flex-wrap: wrap; gap: 1rem; margin-bottom: 1.5rem; }
+  .controls { display: flex; flex-wrap: wrap; gap: 1rem; margin-bottom: 0.75rem; align-items: flex-end; }
+  .strategy-desc { font-size: 0.85rem; color: #555; margin-bottom: 1rem; max-width: 520px; }
   .field { display: flex; flex-direction: column; gap: 0.25rem; }
   label { font-size: 0.85rem; font-weight: bold; }
   select, input { padding: 0.4rem 0.6rem; border: 1px solid #ccc; border-radius: 4px; font-size: 0.95rem; }
@@ -139,11 +155,12 @@
     <div class="field">
       <label for="strategy">Betting Strategy</label>
       <select id="strategy" bind:value={strategyName}>
-        {#each Object.keys(strategyKeys) as s}
+        {#each Object.keys(strategies) as s}
           <option value={s}>{s}</option>
         {/each}
       </select>
     </div>
+    <div class="strategy-desc">{strategies[strategyName].description}</div>
     <div class="field">
       <label for="hands">Hands</label>
       <input id="hands" type="number" min="1" max="10000" bind:value={numHands} style="width:100px" />

--- a/static/craps/App.svelte
+++ b/static/craps/App.svelte
@@ -1,0 +1,526 @@
+<script>
+  // ── settle.js ──────────────────────────────────────────────────────────────
+  function passLine({ bets, hand }) {
+    if (!bets?.pass?.line) return { bets };
+    const actionResults = ['seven out', 'point win', 'comeout win', 'comeout loss'];
+    if (!actionResults.includes(hand.result)) return { bets };
+    const payout = {
+      type: hand.result,
+      principal: bets.pass.line.amount,
+      profit: bets.pass.line.amount
+    };
+    delete bets.pass.line;
+    if (hand.result === 'comeout loss' || hand.result === 'seven out') return { bets };
+    return { payout, bets };
+  }
+
+  function passOdds({ bets, hand }) {
+    if (!bets?.pass?.odds) return { bets };
+    const actionResults = ['seven out', 'point win'];
+    if (!actionResults.includes(hand.result)) return { bets };
+    const oddsTable = { 4: 2, 5: 1.5, 6: 1.2, 8: 1.2, 9: 1.5, 10: 2 };
+    const payout = {
+      type: 'pass odds win',
+      principal: bets.pass.odds.amount,
+      profit: bets.pass.odds.amount * oddsTable[hand.diceSum]
+    };
+    delete bets.pass.odds;
+    if (hand.result === 'seven out') return { bets };
+    return { payout, bets };
+  }
+
+  function placeBet({ rules, bets, hand, placeNumber }) {
+    const label = placeNumber === 6 ? 'six' : placeNumber === 8 ? 'eight' : String(placeNumber);
+    if (!bets?.place?.[label]) return { bets };
+    const comeOutResults = ['comeout win', 'comeout loss', 'point set'];
+    if (comeOutResults.includes(hand.result)) {
+      const bet = bets.place[label];
+      const betWorking = bet.working !== undefined ? bet.working : !(rules?.placeBetsOffOnComeOut);
+      if (!betWorking) return { bets };
+    }
+    if (hand.diceSum === 7 && hand.result === 'seven out') {
+      delete bets.place[label];
+      if (Object.keys(bets.place).length === 0) delete bets.place;
+      return { bets };
+    }
+    if (hand.diceSum === placeNumber && hand.result !== 'point set') {
+      const payouts = { 6: 7 / 6, 8: 7 / 6 };
+      const payout = {
+        type: `place ${placeNumber} win`,
+        principal: bets.place[label].amount,
+        profit: bets.place[label].amount * payouts[placeNumber]
+      };
+      delete bets.place[label];
+      return { payout, bets };
+    }
+    return { bets };
+  }
+
+  function comeLine({ bets, hand }) {
+    if (!bets?.come) return { bets };
+    const payouts = [];
+    bets.come.points = bets.come.points || {};
+    Object.keys(bets.come.points).forEach(point => {
+      const remainingBets = [];
+      bets.come.points[point].forEach(bet => {
+        if (hand.result === 'seven out') return;
+        if (hand.diceSum === Number(point)) {
+          payouts.push({ type: 'come line win', principal: bet.line.amount, profit: bet.line.amount });
+          if (bet.odds) {
+            const oddsTable = { 4: 2, 5: 1.5, 6: 1.2, 8: 1.2, 9: 1.5, 10: 2 };
+            payouts.push({ type: 'come odds win', principal: bet.odds.amount, profit: bet.odds.amount * oddsTable[point] });
+          }
+          return;
+        }
+        remainingBets.push(bet);
+      });
+      if (remainingBets.length) {
+        bets.come.points[point] = remainingBets;
+      } else {
+        delete bets.come.points[point];
+      }
+    });
+    if (Object.keys(bets.come.points).length === 0) delete bets.come.points;
+    const pending = bets.come.pending || [];
+    if (pending.length) {
+      const immediateWins = [7, 11];
+      const immediateLosses = [2, 3, 12];
+      pending.forEach(bet => {
+        if (immediateWins.includes(hand.diceSum)) {
+          payouts.push({ type: 'come line win', principal: bet.amount, profit: bet.amount });
+        } else if (!immediateLosses.includes(hand.diceSum)) {
+          bets.come.points = bets.come.points || {};
+          bets.come.points[hand.diceSum] = bets.come.points[hand.diceSum] || [];
+          bets.come.points[hand.diceSum].push({ line: { amount: bet.amount } });
+        }
+      });
+      delete bets.come.pending;
+    }
+    if (bets.come && Object.keys(bets.come).length === 0) delete bets.come;
+    return { bets, payouts };
+  }
+
+  function settleAll({ bets, hand, rules }) {
+    const payouts = [];
+    let r;
+    r = passLine({ bets, hand }); bets = r.bets; if (r.payout) payouts.push(r.payout);
+    r = passOdds({ bets, hand }); bets = r.bets; if (r.payout) payouts.push(r.payout);
+    r = comeLine({ bets, hand }); bets = r.bets; payouts.push(...(r.payouts || []));
+    r = placeBet({ rules, bets, hand, placeNumber: 6 }); bets = r.bets; if (r.payout) payouts.push(r.payout);
+    r = placeBet({ rules, bets, hand, placeNumber: 8 }); bets = r.bets; if (r.payout) payouts.push(r.payout);
+    const summary = payouts.reduce((m, p) => {
+      m.principal += p.principal; m.profit += p.profit; m.total += p.principal + p.profit; m.ledger.push(p); return m;
+    }, { principal: 0, profit: 0, total: 0, ledger: [] });
+    bets.payouts = summary;
+    return bets;
+  }
+
+  // ── betting.js ─────────────────────────────────────────────────────────────
+  function minPassLineOnly({ rules, bets: eb, hand }) {
+    const bets = Object.assign({ new: 0 }, eb);
+    if (hand.isComeOut && !bets?.pass?.line) {
+      bets.pass = { line: { amount: rules.minBet } };
+      bets.new += rules.minBet;
+    }
+    return bets;
+  }
+
+  function lineMaxOdds({ rules, bets: eb, point, shouldMakeLineBet, shouldMakeOddsBet, betKey = 'pass' }) {
+    const bets = Object.assign({ new: 0 }, eb);
+    bets[betKey] = bets[betKey] || {};
+    if (shouldMakeLineBet && !bets[betKey].line) {
+      bets[betKey].line = { amount: rules.minBet };
+      bets.new += rules.minBet;
+    }
+    if (shouldMakeOddsBet && bets[betKey].line && !bets[betKey].odds) {
+      const oddsAmount = rules.maxOddsMultiple[point] * bets[betKey].line.amount;
+      bets[betKey].odds = { amount: oddsAmount };
+      bets.new += oddsAmount;
+    }
+    return bets;
+  }
+
+  function minPassLineMaxOdds(opts) {
+    return lineMaxOdds({
+      rules: opts.rules, bets: opts.bets, point: opts.hand.point,
+      shouldMakeLineBet: opts.hand.isComeOut, shouldMakeOddsBet: opts.hand.isComeOut === false
+    });
+  }
+
+  function placeSixEight({ rules, bets: eb = {}, hand }) {
+    const bets = Object.assign({ new: 0 }, eb);
+    if (hand.isComeOut) return bets;
+    bets.place = bets.place || {};
+    const placeAmount = Math.ceil(rules.minBet / 6) * 6;
+    if (!bets.place.six) { bets.place.six = { amount: placeAmount }; bets.new += placeAmount; }
+    if (!bets.place.eight) { bets.place.eight = { amount: placeAmount }; bets.new += placeAmount; }
+    return bets;
+  }
+
+  function placeSixEightUnlessPoint(opts) {
+    const { hand } = opts;
+    const bets = placeSixEight(opts);
+    if (hand.point === 6 && bets.place?.six) { bets.new -= bets.place.six.amount; delete bets.place.six; }
+    if (hand.point === 8 && bets.place?.eight) { bets.new -= bets.place.eight.amount; delete bets.place.eight; }
+    if (bets.place && Object.keys(bets.place).length === 0) delete bets.place;
+    return bets;
+  }
+
+  function minComeLineMaxOdds(opts) {
+    const { rules, bets: eb = {}, hand, maxComeBets = 1 } = opts;
+    const bets = Object.assign({ new: 0 }, eb);
+    if (hand.isComeOut) return bets;
+    bets.come = bets.come || {};
+    bets.come.pending = bets.come.pending || [];
+    bets.come.points = bets.come.points || {};
+    const pendingCount = bets.come.pending.length;
+    const pointCount = Object.values(bets.come.points).reduce((m, pb) => m + pb.length, 0);
+    if (pendingCount === 0 && pointCount < maxComeBets) {
+      bets.come.pending.push({ amount: rules.minBet });
+      bets.new += rules.minBet;
+    }
+    Object.keys(bets.come.points).forEach(point => {
+      bets.come.points[point].forEach(bet => {
+        if (!bet.line || bet.odds) return;
+        const oddsAmount = rules.maxOddsMultiple[point] * bet.line.amount;
+        bet.odds = { amount: oddsAmount };
+        bets.new += oddsAmount;
+      });
+    });
+    return bets;
+  }
+
+  function minPassLinePlaceSixEight(opts) {
+    let bets = minPassLineOnly(opts);
+    return placeSixEightUnlessPoint({ ...opts, bets });
+  }
+
+  function minPassLineMaxOddsPlaceSixEight(opts) {
+    let bets = minPassLineMaxOdds(opts);
+    return placeSixEightUnlessPoint({ ...opts, bets });
+  }
+
+  function passCome68(opts) {
+    let bets = minPassLineMaxOdds(opts);
+    bets = minComeLineMaxOdds({ ...opts, bets });
+    const coveredPoints = new Set([opts.hand.point, ...Object.keys(bets?.come?.points || {}).map(Number)]);
+    bets = placeSixEight({ ...opts, bets });
+    if (coveredPoints.has(6) && bets.place?.six) { bets.new -= bets.place.six.amount; delete bets.place.six; }
+    if (coveredPoints.has(8) && bets.place?.eight) { bets.new -= bets.place.eight.amount; delete bets.place.eight; }
+    if (bets.place && Object.keys(bets.place).length === 0) delete bets.place;
+    return bets;
+  }
+
+  const strategies = {
+    'Pass Line Only': minPassLineOnly,
+    'Pass + Max Odds': minPassLineMaxOdds,
+    'Pass + Place 6/8': minPassLinePlaceSixEight,
+    'Pass + Max Odds + Place 6/8': minPassLineMaxOddsPlaceSixEight,
+    'Pass + Come + Place 6/8': passCome68
+  };
+
+  // ── core game logic ────────────────────────────────────────────────────────
+  const defaultRules = {
+    comeOutLoss: [2, 3, 12],
+    comeOutWin: [7, 11],
+    placeBetsOffOnComeOut: true,
+    minBet: 5,
+    maxOddsMultiple: { 4: 3, 5: 4, 6: 5, 8: 5, 9: 4, 10: 3 }
+  };
+
+  function rollD6() { return 1 + Math.floor(Math.random() * 6); }
+
+  function shoot(before, dice, rules) {
+    const sorted = [...dice].sort((a, b) => a - b);
+    const after = { die1: sorted[0], die2: sorted[1], diceSum: dice[0] + dice[1] };
+    if (before.isComeOut) {
+      if (rules.comeOutLoss.includes(after.diceSum)) {
+        after.result = 'comeout loss'; after.isComeOut = true;
+      } else if (rules.comeOutWin.includes(after.diceSum)) {
+        after.result = 'comeout win'; after.isComeOut = true;
+      } else {
+        after.result = 'point set'; after.isComeOut = false; after.point = after.diceSum;
+      }
+    } else {
+      if (before.point === after.diceSum) {
+        after.result = 'point win'; after.isComeOut = true;
+      } else if (after.diceSum === 7) {
+        after.result = 'seven out'; after.isComeOut = true;
+      } else {
+        after.result = 'neutral'; after.point = before.point; after.isComeOut = false;
+      }
+    }
+    return after;
+  }
+
+  function playHand({ rules, bettingStrategy, balance = 0 }) {
+    const history = [];
+    let hand = { isComeOut: true };
+    let bets;
+    const playerMind = {};
+    while (hand.result !== 'seven out') {
+      bets = bettingStrategy({ rules, bets, hand, playerMind });
+      balance -= bets.new;
+      const betsBefore = JSON.parse(JSON.stringify(bets));
+      delete bets.new;
+      hand = shoot(hand, [rollD6(), rollD6()], rules);
+      bets = settleAll({ rules, bets, hand });
+      const payouts = bets.payouts;
+      if (payouts?.total) balance += payouts.total;
+      if (payouts?.ledger?.length) hand.payouts = payouts.ledger;
+      if (payouts) delete bets.payouts;
+      hand.betsBefore = betsBefore;
+      history.push(hand);
+    }
+    return { history, balance };
+  }
+
+  // ── UI state ───────────────────────────────────────────────────────────────
+  let strategyName = 'Pass Line Only';
+  let numSessions = 50;
+  let minBet = 5;
+  let maxOdds = 3; // multiplier applied uniformly for simplicity
+
+  let results = null;
+  let lastHistory = null;
+  let showHistory = false;
+
+  const resultLabels = {
+    'comeout win': 'Come-out Win',
+    'comeout loss': 'Come-out Loss',
+    'point set': 'Point Set',
+    'point win': 'Point Win',
+    'seven out': 'Seven Out',
+    'neutral': 'Neutral'
+  };
+
+  const resultColors = {
+    'comeout win': '#22c55e',
+    'point win': '#22c55e',
+    'seven out': '#ef4444',
+    'comeout loss': '#ef4444',
+    'point set': '#3b82f6',
+    'neutral': '#888'
+  };
+
+  function buildRules() {
+    return {
+      ...defaultRules,
+      minBet,
+      maxOddsMultiple: { 4: maxOdds, 5: maxOdds, 6: maxOdds, 8: maxOdds, 9: maxOdds, 10: maxOdds }
+    };
+  }
+
+  function simulate() {
+    const rules = buildRules();
+    const strategy = strategies[strategyName];
+    const sessionResults = [];
+    let totalWagered = 0;
+    let totalReturned = 0;
+    let wins = 0;
+    let losses = 0;
+
+    for (let i = 0; i < numSessions; i++) {
+      const { history, balance } = playHand({ rules, bettingStrategy: strategy });
+      const sessionWagered = history.reduce((sum, roll) => {
+        const b = roll.betsBefore;
+        return sum + Object.values(b).reduce((s, v) => {
+          if (typeof v === 'number') return s;
+          if (v?.line) s += v.line.amount || 0;
+          if (v?.odds) s += v.odds.amount || 0;
+          if (v?.place) {
+            if (v.place.six) s += v.place.six.amount || 0;
+            if (v.place.eight) s += v.place.eight.amount || 0;
+          }
+          return s;
+        }, 0);
+      }, 0);
+
+      const gained = history.reduce((sum, roll) => {
+        return sum + (roll.payouts?.reduce((s, p) => s + p.principal + p.profit, 0) || 0);
+      }, 0);
+
+      totalWagered += sessionWagered;
+      totalReturned += gained;
+      if (balance >= 0) wins++; else losses++;
+      sessionResults.push({ rolls: history.length, balance });
+      if (i === numSessions - 1) lastHistory = history;
+    }
+
+    const avgBalance = sessionResults.reduce((s, r) => s + r.balance, 0) / numSessions;
+    const avgRolls = sessionResults.reduce((s, r) => s + r.rolls, 0) / numSessions;
+    const minBalance = Math.min(...sessionResults.map(r => r.balance));
+    const maxBalance = Math.max(...sessionResults.map(r => r.balance));
+    const houseEdge = totalWagered > 0 ? ((totalWagered - totalReturned) / totalWagered * 100) : 0;
+
+    results = {
+      sessions: numSessions,
+      wins,
+      losses,
+      avgBalance: avgBalance.toFixed(2),
+      avgRolls: avgRolls.toFixed(1),
+      minBalance,
+      maxBalance,
+      houseEdge: houseEdge.toFixed(2),
+      sessionResults
+    };
+    showHistory = false;
+  }
+
+  function fmt(n) {
+    const v = Number(n);
+    const sign = v >= 0 ? '+' : '';
+    return `${sign}$${v.toFixed(2)}`;
+  }
+</script>
+
+<style>
+  * { box-sizing: border-box; }
+  h1 { margin: 0 0 1rem 0; font-size: 1.4rem; }
+  h2 { font-size: 1.1rem; margin: 1.2rem 0 0.5rem 0; }
+  .controls { display: flex; flex-wrap: wrap; gap: 1rem; margin-bottom: 1.5rem; }
+  .field { display: flex; flex-direction: column; gap: 0.25rem; }
+  label { font-size: 0.85rem; font-weight: bold; }
+  select, input { padding: 0.4rem 0.6rem; border: 1px solid #ccc; border-radius: 4px; font-size: 0.95rem; }
+  button { padding: 0.5rem 1.2rem; background: #333; color: #fff; border: none; border-radius: 4px; cursor: pointer; font-size: 1rem; }
+  button:hover { background: #555; }
+  .stats-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(160px, 1fr)); gap: 0.75rem; margin: 1rem 0; }
+  .stat { border: 1px solid #ddd; border-radius: 6px; padding: 0.75rem; }
+  .stat-label { font-size: 0.75rem; color: #666; margin-bottom: 0.2rem; }
+  .stat-value { font-size: 1.3rem; font-weight: bold; }
+  .positive { color: #16a34a; }
+  .negative { color: #dc2626; }
+  .neutral-color { color: #555; }
+  table { border-collapse: collapse; width: 100%; font-size: 0.9rem; }
+  th, td { border: 1px solid #ddd; padding: 5px 8px; text-align: left; }
+  th { background: #f5f5f5; font-size: 0.8rem; }
+  .roll-result { font-weight: bold; }
+  .tag { display: inline-block; font-size: 0.75rem; padding: 1px 6px; border-radius: 3px; color: #fff; margin-right: 3px; }
+  .toggle { background: none; color: #333; border: 1px solid #ccc; margin-top: 0.5rem; font-size: 0.85rem; padding: 0.3rem 0.8rem; }
+  .session-chart { display: flex; flex-wrap: wrap; gap: 4px; margin: 0.5rem 0; }
+  .session-dot { width: 14px; height: 14px; border-radius: 2px; title: attr(data-val); }
+  .hist-wrap { overflow-x: auto; }
+</style>
+
+<h1>Craps Simulator</h1>
+<p>Simulate craps sessions using betting strategies from <a href="https://github.com/tphummel/node-craps" target="_blank">node-craps</a>.</p>
+
+<div class="controls">
+  <div class="field">
+    <label for="strategy">Betting Strategy</label>
+    <select id="strategy" bind:value={strategyName}>
+      {#each Object.keys(strategies) as s}
+        <option value={s}>{s}</option>
+      {/each}
+    </select>
+  </div>
+  <div class="field">
+    <label for="sessions">Sessions</label>
+    <input id="sessions" type="number" min="1" max="10000" bind:value={numSessions} style="width:100px" />
+  </div>
+  <div class="field">
+    <label for="minbet">Min Bet ($)</label>
+    <input id="minbet" type="number" min="1" max="500" bind:value={minBet} style="width:80px" />
+  </div>
+  <div class="field">
+    <label for="maxodds">Max Odds (×)</label>
+    <input id="maxodds" type="number" min="0" max="100" bind:value={maxOdds} style="width:80px" />
+  </div>
+  <div class="field" style="justify-content:flex-end">
+    <button on:click={simulate}>Simulate</button>
+  </div>
+</div>
+
+{#if results}
+  <h2>Results — {results.sessions} sessions</h2>
+  <div class="stats-grid">
+    <div class="stat">
+      <div class="stat-label">Avg Net / Session</div>
+      <div class="stat-value {Number(results.avgBalance) >= 0 ? 'positive' : 'negative'}">{fmt(results.avgBalance)}</div>
+    </div>
+    <div class="stat">
+      <div class="stat-label">Win / Loss Sessions</div>
+      <div class="stat-value neutral-color">{results.wins} / {results.losses}</div>
+    </div>
+    <div class="stat">
+      <div class="stat-label">Win Rate</div>
+      <div class="stat-value neutral-color">{(results.wins / results.sessions * 100).toFixed(1)}%</div>
+    </div>
+    <div class="stat">
+      <div class="stat-label">Avg Rolls / Session</div>
+      <div class="stat-value neutral-color">{results.avgRolls}</div>
+    </div>
+    <div class="stat">
+      <div class="stat-label">Best Session</div>
+      <div class="stat-value positive">{fmt(results.maxBalance)}</div>
+    </div>
+    <div class="stat">
+      <div class="stat-label">Worst Session</div>
+      <div class="stat-value negative">{fmt(results.minBalance)}</div>
+    </div>
+    <div class="stat">
+      <div class="stat-label">Est. House Edge</div>
+      <div class="stat-value negative">{results.houseEdge}%</div>
+    </div>
+  </div>
+
+  <h2>Session Results</h2>
+  <div class="session-chart">
+    {#each results.sessionResults as s, i}
+      <div
+        class="session-dot"
+        style="background:{s.balance >= 0 ? '#22c55e' : '#ef4444'}; opacity:{Math.min(1, 0.4 + Math.abs(s.balance) / (Math.abs(results.minBalance) || 1) * 0.6)}"
+        title="Session {i+1}: {fmt(s.balance)} ({s.rolls} rolls)"
+      ></div>
+    {/each}
+  </div>
+
+  {#if lastHistory}
+    <button class="toggle" on:click={() => showHistory = !showHistory}>
+      {showHistory ? 'Hide' : 'Show'} Last Session Roll-by-Roll
+    </button>
+
+    {#if showHistory}
+      <div class="hist-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>Dice</th>
+              <th>Sum</th>
+              <th>Result</th>
+              <th>Point</th>
+              <th>Payouts</th>
+            </tr>
+          </thead>
+          <tbody>
+            {#each lastHistory as roll, i}
+              <tr>
+                <td>{i + 1}</td>
+                <td>{roll.die1} + {roll.die2}</td>
+                <td>{roll.diceSum}</td>
+                <td>
+                  <span class="roll-result" style="color:{resultColors[roll.result] || '#333'}">
+                    {resultLabels[roll.result] || roll.result}
+                  </span>
+                </td>
+                <td>{roll.point ?? '—'}</td>
+                <td>
+                  {#if roll.payouts?.length}
+                    {#each roll.payouts as p}
+                      <span class="tag" style="background:{resultColors[roll.result] || '#888'}">
+                        {p.type}: +${(p.principal + p.profit).toFixed(0)}
+                      </span>
+                    {/each}
+                  {:else}
+                    —
+                  {/if}
+                </td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      </div>
+    {/if}
+  {/if}
+{/if}

--- a/static/craps/App.svelte
+++ b/static/craps/App.svelte
@@ -1,311 +1,57 @@
 <script>
-  // ── settle.js ──────────────────────────────────────────────────────────────
-  function passLine({ bets, hand }) {
-    if (!bets?.pass?.line) return { bets };
-    const actionResults = ['seven out', 'point win', 'comeout win', 'comeout loss'];
-    if (!actionResults.includes(hand.result)) return { bets };
-    const payout = {
-      type: hand.result,
-      principal: bets.pass.line.amount,
-      profit: bets.pass.line.amount
-    };
-    delete bets.pass.line;
-    if (hand.result === 'comeout loss' || hand.result === 'seven out') return { bets };
-    return { payout, bets };
-  }
+  import { onMount } from 'svelte';
 
-  function passOdds({ bets, hand }) {
-    if (!bets?.pass?.odds) return { bets };
-    const actionResults = ['seven out', 'point win'];
-    if (!actionResults.includes(hand.result)) return { bets };
-    const oddsTable = { 4: 2, 5: 1.5, 6: 1.2, 8: 1.2, 9: 1.5, 10: 2 };
-    const payout = {
-      type: 'pass odds win',
-      principal: bets.pass.odds.amount,
-      profit: bets.pass.odds.amount * oddsTable[hand.diceSum]
-    };
-    delete bets.pass.odds;
-    if (hand.result === 'seven out') return { bets };
-    return { payout, bets };
-  }
+  const MODULE_URL = 'https://esm.sh/gh/tphummel/node-craps';
 
-  function placeBet({ rules, bets, hand, placeNumber }) {
-    const label = placeNumber === 6 ? 'six' : placeNumber === 8 ? 'eight' : String(placeNumber);
-    if (!bets?.place?.[label]) return { bets };
-    const comeOutResults = ['comeout win', 'comeout loss', 'point set'];
-    if (comeOutResults.includes(hand.result)) {
-      const bet = bets.place[label];
-      const betWorking = bet.working !== undefined ? bet.working : !(rules?.placeBetsOffOnComeOut);
-      if (!betWorking) return { bets };
+  let craps = null;
+  let loadError = null;
+
+  onMount(async () => {
+    try {
+      craps = await import(MODULE_URL);
+    } catch (err) {
+      loadError = err.message;
     }
-    if (hand.diceSum === 7 && hand.result === 'seven out') {
-      delete bets.place[label];
-      if (Object.keys(bets.place).length === 0) delete bets.place;
-      return { bets };
-    }
-    if (hand.diceSum === placeNumber && hand.result !== 'point set') {
-      const payouts = { 6: 7 / 6, 8: 7 / 6 };
-      const payout = {
-        type: `place ${placeNumber} win`,
-        principal: bets.place[label].amount,
-        profit: bets.place[label].amount * payouts[placeNumber]
-      };
-      delete bets.place[label];
-      return { payout, bets };
-    }
-    return { bets };
-  }
+  });
 
-  function comeLine({ bets, hand }) {
-    if (!bets?.come) return { bets };
-    const payouts = [];
-    bets.come.points = bets.come.points || {};
-    Object.keys(bets.come.points).forEach(point => {
-      const remainingBets = [];
-      bets.come.points[point].forEach(bet => {
-        if (hand.result === 'seven out') return;
-        if (hand.diceSum === Number(point)) {
-          payouts.push({ type: 'come line win', principal: bet.line.amount, profit: bet.line.amount });
-          if (bet.odds) {
-            const oddsTable = { 4: 2, 5: 1.5, 6: 1.2, 8: 1.2, 9: 1.5, 10: 2 };
-            payouts.push({ type: 'come odds win', principal: bet.odds.amount, profit: bet.odds.amount * oddsTable[point] });
-          }
-          return;
-        }
-        remainingBets.push(bet);
-      });
-      if (remainingBets.length) {
-        bets.come.points[point] = remainingBets;
-      } else {
-        delete bets.come.points[point];
-      }
-    });
-    if (Object.keys(bets.come.points).length === 0) delete bets.come.points;
-    const pending = bets.come.pending || [];
-    if (pending.length) {
-      const immediateWins = [7, 11];
-      const immediateLosses = [2, 3, 12];
-      pending.forEach(bet => {
-        if (immediateWins.includes(hand.diceSum)) {
-          payouts.push({ type: 'come line win', principal: bet.amount, profit: bet.amount });
-        } else if (!immediateLosses.includes(hand.diceSum)) {
-          bets.come.points = bets.come.points || {};
-          bets.come.points[hand.diceSum] = bets.come.points[hand.diceSum] || [];
-          bets.come.points[hand.diceSum].push({ line: { amount: bet.amount } });
-        }
-      });
-      delete bets.come.pending;
-    }
-    if (bets.come && Object.keys(bets.come).length === 0) delete bets.come;
-    return { bets, payouts };
-  }
-
-  function settleAll({ bets, hand, rules }) {
-    const payouts = [];
-    let r;
-    r = passLine({ bets, hand }); bets = r.bets; if (r.payout) payouts.push(r.payout);
-    r = passOdds({ bets, hand }); bets = r.bets; if (r.payout) payouts.push(r.payout);
-    r = comeLine({ bets, hand }); bets = r.bets; payouts.push(...(r.payouts || []));
-    r = placeBet({ rules, bets, hand, placeNumber: 6 }); bets = r.bets; if (r.payout) payouts.push(r.payout);
-    r = placeBet({ rules, bets, hand, placeNumber: 8 }); bets = r.bets; if (r.payout) payouts.push(r.payout);
-    const summary = payouts.reduce((m, p) => {
-      m.principal += p.principal; m.profit += p.profit; m.total += p.principal + p.profit; m.ledger.push(p); return m;
-    }, { principal: 0, profit: 0, total: 0, ledger: [] });
-    bets.payouts = summary;
-    return bets;
-  }
-
-  // ── betting.js ─────────────────────────────────────────────────────────────
-  function minPassLineOnly({ rules, bets: eb, hand }) {
-    const bets = Object.assign({ new: 0 }, eb);
-    if (hand.isComeOut && !bets?.pass?.line) {
-      bets.pass = { line: { amount: rules.minBet } };
-      bets.new += rules.minBet;
-    }
-    return bets;
-  }
-
-  function lineMaxOdds({ rules, bets: eb, point, shouldMakeLineBet, shouldMakeOddsBet, betKey = 'pass' }) {
-    const bets = Object.assign({ new: 0 }, eb);
-    bets[betKey] = bets[betKey] || {};
-    if (shouldMakeLineBet && !bets[betKey].line) {
-      bets[betKey].line = { amount: rules.minBet };
-      bets.new += rules.minBet;
-    }
-    if (shouldMakeOddsBet && bets[betKey].line && !bets[betKey].odds) {
-      const oddsAmount = rules.maxOddsMultiple[point] * bets[betKey].line.amount;
-      bets[betKey].odds = { amount: oddsAmount };
-      bets.new += oddsAmount;
-    }
-    return bets;
-  }
-
-  function minPassLineMaxOdds(opts) {
-    return lineMaxOdds({
-      rules: opts.rules, bets: opts.bets, point: opts.hand.point,
-      shouldMakeLineBet: opts.hand.isComeOut, shouldMakeOddsBet: opts.hand.isComeOut === false
-    });
-  }
-
-  function placeSixEight({ rules, bets: eb = {}, hand }) {
-    const bets = Object.assign({ new: 0 }, eb);
-    if (hand.isComeOut) return bets;
-    bets.place = bets.place || {};
-    const placeAmount = Math.ceil(rules.minBet / 6) * 6;
-    if (!bets.place.six) { bets.place.six = { amount: placeAmount }; bets.new += placeAmount; }
-    if (!bets.place.eight) { bets.place.eight = { amount: placeAmount }; bets.new += placeAmount; }
-    return bets;
-  }
-
-  function placeSixEightUnlessPoint(opts) {
-    const { hand } = opts;
-    const bets = placeSixEight(opts);
-    if (hand.point === 6 && bets.place?.six) { bets.new -= bets.place.six.amount; delete bets.place.six; }
-    if (hand.point === 8 && bets.place?.eight) { bets.new -= bets.place.eight.amount; delete bets.place.eight; }
-    if (bets.place && Object.keys(bets.place).length === 0) delete bets.place;
-    return bets;
-  }
-
-  function minComeLineMaxOdds(opts) {
-    const { rules, bets: eb = {}, hand, maxComeBets = 1 } = opts;
-    const bets = Object.assign({ new: 0 }, eb);
-    if (hand.isComeOut) return bets;
-    bets.come = bets.come || {};
-    bets.come.pending = bets.come.pending || [];
-    bets.come.points = bets.come.points || {};
-    const pendingCount = bets.come.pending.length;
-    const pointCount = Object.values(bets.come.points).reduce((m, pb) => m + pb.length, 0);
-    if (pendingCount === 0 && pointCount < maxComeBets) {
-      bets.come.pending.push({ amount: rules.minBet });
-      bets.new += rules.minBet;
-    }
-    Object.keys(bets.come.points).forEach(point => {
-      bets.come.points[point].forEach(bet => {
-        if (!bet.line || bet.odds) return;
-        const oddsAmount = rules.maxOddsMultiple[point] * bet.line.amount;
-        bet.odds = { amount: oddsAmount };
-        bets.new += oddsAmount;
-      });
-    });
-    return bets;
-  }
-
-  function minPassLinePlaceSixEight(opts) {
-    let bets = minPassLineOnly(opts);
-    return placeSixEightUnlessPoint({ ...opts, bets });
-  }
-
-  function minPassLineMaxOddsPlaceSixEight(opts) {
-    let bets = minPassLineMaxOdds(opts);
-    return placeSixEightUnlessPoint({ ...opts, bets });
-  }
-
-  function passCome68(opts) {
-    let bets = minPassLineMaxOdds(opts);
-    bets = minComeLineMaxOdds({ ...opts, bets });
-    const coveredPoints = new Set([opts.hand.point, ...Object.keys(bets?.come?.points || {}).map(Number)]);
-    bets = placeSixEight({ ...opts, bets });
-    if (coveredPoints.has(6) && bets.place?.six) { bets.new -= bets.place.six.amount; delete bets.place.six; }
-    if (coveredPoints.has(8) && bets.place?.eight) { bets.new -= bets.place.eight.amount; delete bets.place.eight; }
-    if (bets.place && Object.keys(bets.place).length === 0) delete bets.place;
-    return bets;
-  }
-
-  const strategies = {
-    'Pass Line Only': minPassLineOnly,
-    'Pass + Max Odds': minPassLineMaxOdds,
-    'Pass + Place 6/8': minPassLinePlaceSixEight,
-    'Pass + Max Odds + Place 6/8': minPassLineMaxOddsPlaceSixEight,
-    'Pass + Come + Place 6/8': passCome68
+  const strategyKeys = {
+    'Pass Line Only':              'minPassLineOnly',
+    'Pass + Max Odds':             'minPassLineMaxOdds',
+    'Pass + Place 6/8':            'minPassLinePlaceSixEight',
+    'Pass + Max Odds + Place 6/8': 'minPassLineMaxOddsPlaceSixEight',
+    'Pass + Come + Place 6/8':     'passCome68',
   };
 
-  // ── core game logic ────────────────────────────────────────────────────────
-  const defaultRules = {
-    comeOutLoss: [2, 3, 12],
-    comeOutWin: [7, 11],
-    placeBetsOffOnComeOut: true,
-    minBet: 5,
-    maxOddsMultiple: { 4: 3, 5: 4, 6: 5, 8: 5, 9: 4, 10: 3 }
-  };
-
-  function rollD6() { return 1 + Math.floor(Math.random() * 6); }
-
-  function shoot(before, dice, rules) {
-    const sorted = [...dice].sort((a, b) => a - b);
-    const after = { die1: sorted[0], die2: sorted[1], diceSum: dice[0] + dice[1] };
-    if (before.isComeOut) {
-      if (rules.comeOutLoss.includes(after.diceSum)) {
-        after.result = 'comeout loss'; after.isComeOut = true;
-      } else if (rules.comeOutWin.includes(after.diceSum)) {
-        after.result = 'comeout win'; after.isComeOut = true;
-      } else {
-        after.result = 'point set'; after.isComeOut = false; after.point = after.diceSum;
-      }
-    } else {
-      if (before.point === after.diceSum) {
-        after.result = 'point win'; after.isComeOut = true;
-      } else if (after.diceSum === 7) {
-        after.result = 'seven out'; after.isComeOut = true;
-      } else {
-        after.result = 'neutral'; after.point = before.point; after.isComeOut = false;
-      }
-    }
-    return after;
-  }
-
-  function playHand({ rules, bettingStrategy, balance = 0 }) {
-    const history = [];
-    let hand = { isComeOut: true };
-    let bets;
-    const playerMind = {};
-    while (hand.result !== 'seven out') {
-      bets = bettingStrategy({ rules, bets, hand, playerMind });
-      balance -= bets.new;
-      const betsBefore = JSON.parse(JSON.stringify(bets));
-      delete bets.new;
-      hand = shoot(hand, [rollD6(), rollD6()], rules);
-      bets = settleAll({ rules, bets, hand });
-      const payouts = bets.payouts;
-      if (payouts?.total) balance += payouts.total;
-      if (payouts?.ledger?.length) hand.payouts = payouts.ledger;
-      if (payouts) delete bets.payouts;
-      hand.betsBefore = betsBefore;
-      history.push(hand);
-    }
-    return { history, balance };
-  }
-
-  // ── UI state ───────────────────────────────────────────────────────────────
   let strategyName = 'Pass Line Only';
   let numSessions = 50;
   let minBet = 5;
-  let maxOdds = 3; // multiplier applied uniformly for simplicity
+  let maxOdds = 3;
 
   let results = null;
   let lastHistory = null;
   let showHistory = false;
 
   const resultLabels = {
-    'comeout win': 'Come-out Win',
+    'comeout win':  'Come-out Win',
     'comeout loss': 'Come-out Loss',
-    'point set': 'Point Set',
-    'point win': 'Point Win',
-    'seven out': 'Seven Out',
-    'neutral': 'Neutral'
+    'point set':    'Point Set',
+    'point win':    'Point Win',
+    'seven out':    'Seven Out',
+    'neutral':      'Neutral'
   };
 
   const resultColors = {
-    'comeout win': '#22c55e',
-    'point win': '#22c55e',
-    'seven out': '#ef4444',
+    'comeout win':  '#22c55e',
+    'point win':    '#22c55e',
+    'seven out':    '#ef4444',
     'comeout loss': '#ef4444',
-    'point set': '#3b82f6',
-    'neutral': '#888'
+    'point set':    '#3b82f6',
+    'neutral':      '#888'
   };
 
   function buildRules() {
     return {
-      ...defaultRules,
+      ...craps.defaultRules,
       minBet,
       maxOddsMultiple: { 4: maxOdds, 5: maxOdds, 6: maxOdds, 8: maxOdds, 9: maxOdds, 10: maxOdds }
     };
@@ -313,34 +59,20 @@
 
   function simulate() {
     const rules = buildRules();
-    const strategy = strategies[strategyName];
+    const bettingStrategy = craps.betting[strategyKeys[strategyName]];
     const sessionResults = [];
-    let totalWagered = 0;
-    let totalReturned = 0;
     let wins = 0;
     let losses = 0;
+    let totalWagered = 0;
+    let totalReturned = 0;
 
     for (let i = 0; i < numSessions; i++) {
-      const { history, balance } = playHand({ rules, bettingStrategy: strategy });
-      const sessionWagered = history.reduce((sum, roll) => {
-        const b = roll.betsBefore;
-        return sum + Object.values(b).reduce((s, v) => {
-          if (typeof v === 'number') return s;
-          if (v?.line) s += v.line.amount || 0;
-          if (v?.odds) s += v.odds.amount || 0;
-          if (v?.place) {
-            if (v.place.six) s += v.place.six.amount || 0;
-            if (v.place.eight) s += v.place.eight.amount || 0;
-          }
-          return s;
-        }, 0);
-      }, 0);
+      const { history, balance } = craps.playHand({ rules, bettingStrategy });
 
       const gained = history.reduce((sum, roll) => {
         return sum + (roll.payouts?.reduce((s, p) => s + p.principal + p.profit, 0) || 0);
       }, 0);
 
-      totalWagered += sessionWagered;
       totalReturned += gained;
       if (balance >= 0) wins++; else losses++;
       sessionResults.push({ rolls: history.length, balance });
@@ -348,20 +80,18 @@
     }
 
     const avgBalance = sessionResults.reduce((s, r) => s + r.balance, 0) / numSessions;
-    const avgRolls = sessionResults.reduce((s, r) => s + r.rolls, 0) / numSessions;
+    const avgRolls   = sessionResults.reduce((s, r) => s + r.rolls,   0) / numSessions;
     const minBalance = Math.min(...sessionResults.map(r => r.balance));
     const maxBalance = Math.max(...sessionResults.map(r => r.balance));
-    const houseEdge = totalWagered > 0 ? ((totalWagered - totalReturned) / totalWagered * 100) : 0;
 
     results = {
       sessions: numSessions,
       wins,
       losses,
       avgBalance: avgBalance.toFixed(2),
-      avgRolls: avgRolls.toFixed(1),
+      avgRolls:   avgRolls.toFixed(1),
       minBalance,
       maxBalance,
-      houseEdge: houseEdge.toFixed(2),
       sessionResults
     };
     showHistory = false;
@@ -369,8 +99,7 @@
 
   function fmt(n) {
     const v = Number(n);
-    const sign = v >= 0 ? '+' : '';
-    return `${sign}$${v.toFixed(2)}`;
+    return `${v >= 0 ? '+' : ''}$${v.toFixed(2)}`;
   }
 </script>
 
@@ -384,6 +113,7 @@
   select, input { padding: 0.4rem 0.6rem; border: 1px solid #ccc; border-radius: 4px; font-size: 0.95rem; }
   button { padding: 0.5rem 1.2rem; background: #333; color: #fff; border: none; border-radius: 4px; cursor: pointer; font-size: 1rem; }
   button:hover { background: #555; }
+  button:disabled { opacity: 0.4; cursor: not-allowed; }
   .stats-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(160px, 1fr)); gap: 0.75rem; margin: 1rem 0; }
   .stat { border: 1px solid #ddd; border-radius: 6px; padding: 0.75rem; }
   .stat-label { font-size: 0.75rem; color: #666; margin-bottom: 0.2rem; }
@@ -398,129 +128,125 @@
   .tag { display: inline-block; font-size: 0.75rem; padding: 1px 6px; border-radius: 3px; color: #fff; margin-right: 3px; }
   .toggle { background: none; color: #333; border: 1px solid #ccc; margin-top: 0.5rem; font-size: 0.85rem; padding: 0.3rem 0.8rem; }
   .session-chart { display: flex; flex-wrap: wrap; gap: 4px; margin: 0.5rem 0; }
-  .session-dot { width: 14px; height: 14px; border-radius: 2px; title: attr(data-val); }
+  .session-dot { width: 14px; height: 14px; border-radius: 2px; }
   .hist-wrap { overflow-x: auto; }
+  .error { color: #dc2626; font-family: monospace; }
 </style>
 
 <h1>Craps Simulator</h1>
 <p>Simulate craps sessions using betting strategies from <a href="https://github.com/tphummel/node-craps" target="_blank">node-craps</a>.</p>
 
-<div class="controls">
-  <div class="field">
-    <label for="strategy">Betting Strategy</label>
-    <select id="strategy" bind:value={strategyName}>
-      {#each Object.keys(strategies) as s}
-        <option value={s}>{s}</option>
-      {/each}
-    </select>
-  </div>
-  <div class="field">
-    <label for="sessions">Sessions</label>
-    <input id="sessions" type="number" min="1" max="10000" bind:value={numSessions} style="width:100px" />
-  </div>
-  <div class="field">
-    <label for="minbet">Min Bet ($)</label>
-    <input id="minbet" type="number" min="1" max="500" bind:value={minBet} style="width:80px" />
-  </div>
-  <div class="field">
-    <label for="maxodds">Max Odds (×)</label>
-    <input id="maxodds" type="number" min="0" max="100" bind:value={maxOdds} style="width:80px" />
-  </div>
-  <div class="field" style="justify-content:flex-end">
-    <button on:click={simulate}>Simulate</button>
-  </div>
-</div>
-
-{#if results}
-  <h2>Results — {results.sessions} sessions</h2>
-  <div class="stats-grid">
-    <div class="stat">
-      <div class="stat-label">Avg Net / Session</div>
-      <div class="stat-value {Number(results.avgBalance) >= 0 ? 'positive' : 'negative'}">{fmt(results.avgBalance)}</div>
+{#if loadError}
+  <p class="error">Failed to load module: {loadError}</p>
+{:else}
+  <div class="controls">
+    <div class="field">
+      <label for="strategy">Betting Strategy</label>
+      <select id="strategy" bind:value={strategyName}>
+        {#each Object.keys(strategyKeys) as s}
+          <option value={s}>{s}</option>
+        {/each}
+      </select>
     </div>
-    <div class="stat">
-      <div class="stat-label">Win / Loss Sessions</div>
-      <div class="stat-value neutral-color">{results.wins} / {results.losses}</div>
+    <div class="field">
+      <label for="sessions">Sessions</label>
+      <input id="sessions" type="number" min="1" max="10000" bind:value={numSessions} style="width:100px" />
     </div>
-    <div class="stat">
-      <div class="stat-label">Win Rate</div>
-      <div class="stat-value neutral-color">{(results.wins / results.sessions * 100).toFixed(1)}%</div>
+    <div class="field">
+      <label for="minbet">Min Bet ($)</label>
+      <input id="minbet" type="number" min="1" max="500" bind:value={minBet} style="width:80px" />
     </div>
-    <div class="stat">
-      <div class="stat-label">Avg Rolls / Session</div>
-      <div class="stat-value neutral-color">{results.avgRolls}</div>
+    <div class="field">
+      <label for="maxodds">Max Odds (×)</label>
+      <input id="maxodds" type="number" min="0" max="100" bind:value={maxOdds} style="width:80px" />
     </div>
-    <div class="stat">
-      <div class="stat-label">Best Session</div>
-      <div class="stat-value positive">{fmt(results.maxBalance)}</div>
-    </div>
-    <div class="stat">
-      <div class="stat-label">Worst Session</div>
-      <div class="stat-value negative">{fmt(results.minBalance)}</div>
-    </div>
-    <div class="stat">
-      <div class="stat-label">Est. House Edge</div>
-      <div class="stat-value negative">{results.houseEdge}%</div>
+    <div class="field" style="justify-content:flex-end">
+      <button on:click={simulate} disabled={!craps}>
+        {craps ? 'Simulate' : 'Loading…'}
+      </button>
     </div>
   </div>
 
-  <h2>Session Results</h2>
-  <div class="session-chart">
-    {#each results.sessionResults as s, i}
-      <div
-        class="session-dot"
-        style="background:{s.balance >= 0 ? '#22c55e' : '#ef4444'}; opacity:{Math.min(1, 0.4 + Math.abs(s.balance) / (Math.abs(results.minBalance) || 1) * 0.6)}"
-        title="Session {i+1}: {fmt(s.balance)} ({s.rolls} rolls)"
-      ></div>
-    {/each}
-  </div>
-
-  {#if lastHistory}
-    <button class="toggle" on:click={() => showHistory = !showHistory}>
-      {showHistory ? 'Hide' : 'Show'} Last Session Roll-by-Roll
-    </button>
-
-    {#if showHistory}
-      <div class="hist-wrap">
-        <table>
-          <thead>
-            <tr>
-              <th>#</th>
-              <th>Dice</th>
-              <th>Sum</th>
-              <th>Result</th>
-              <th>Point</th>
-              <th>Payouts</th>
-            </tr>
-          </thead>
-          <tbody>
-            {#each lastHistory as roll, i}
-              <tr>
-                <td>{i + 1}</td>
-                <td>{roll.die1} + {roll.die2}</td>
-                <td>{roll.diceSum}</td>
-                <td>
-                  <span class="roll-result" style="color:{resultColors[roll.result] || '#333'}">
-                    {resultLabels[roll.result] || roll.result}
-                  </span>
-                </td>
-                <td>{roll.point ?? '—'}</td>
-                <td>
-                  {#if roll.payouts?.length}
-                    {#each roll.payouts as p}
-                      <span class="tag" style="background:{resultColors[roll.result] || '#888'}">
-                        {p.type}: +${(p.principal + p.profit).toFixed(0)}
-                      </span>
-                    {/each}
-                  {:else}
-                    —
-                  {/if}
-                </td>
-              </tr>
-            {/each}
-          </tbody>
-        </table>
+  {#if results}
+    <h2>Results — {results.sessions} sessions</h2>
+    <div class="stats-grid">
+      <div class="stat">
+        <div class="stat-label">Avg Net / Session</div>
+        <div class="stat-value {Number(results.avgBalance) >= 0 ? 'positive' : 'negative'}">{fmt(results.avgBalance)}</div>
       </div>
+      <div class="stat">
+        <div class="stat-label">Win / Loss Sessions</div>
+        <div class="stat-value neutral-color">{results.wins} / {results.losses}</div>
+      </div>
+      <div class="stat">
+        <div class="stat-label">Win Rate</div>
+        <div class="stat-value neutral-color">{(results.wins / results.sessions * 100).toFixed(1)}%</div>
+      </div>
+      <div class="stat">
+        <div class="stat-label">Avg Rolls / Session</div>
+        <div class="stat-value neutral-color">{results.avgRolls}</div>
+      </div>
+      <div class="stat">
+        <div class="stat-label">Best Session</div>
+        <div class="stat-value positive">{fmt(results.maxBalance)}</div>
+      </div>
+      <div class="stat">
+        <div class="stat-label">Worst Session</div>
+        <div class="stat-value negative">{fmt(results.minBalance)}</div>
+      </div>
+    </div>
+
+    <h2>Session Results</h2>
+    <div class="session-chart">
+      {#each results.sessionResults as s, i}
+        <div
+          class="session-dot"
+          style="background:{s.balance >= 0 ? '#22c55e' : '#ef4444'}"
+          title="Session {i+1}: {fmt(s.balance)} ({s.rolls} rolls)"
+        ></div>
+      {/each}
+    </div>
+
+    {#if lastHistory}
+      <button class="toggle" on:click={() => showHistory = !showHistory}>
+        {showHistory ? 'Hide' : 'Show'} Last Session Roll-by-Roll
+      </button>
+
+      {#if showHistory}
+        <div class="hist-wrap">
+          <table>
+            <thead>
+              <tr><th>#</th><th>Dice</th><th>Sum</th><th>Result</th><th>Point</th><th>Payouts</th></tr>
+            </thead>
+            <tbody>
+              {#each lastHistory as roll, i}
+                <tr>
+                  <td>{i + 1}</td>
+                  <td>{roll.die1} + {roll.die2}</td>
+                  <td>{roll.diceSum}</td>
+                  <td>
+                    <span class="roll-result" style="color:{resultColors[roll.result] || '#333'}">
+                      {resultLabels[roll.result] || roll.result}
+                    </span>
+                  </td>
+                  <td>{roll.point ?? '—'}</td>
+                  <td>
+                    {#if roll.payouts?.length}
+                      {#each roll.payouts as p}
+                        <span class="tag" style="background:{resultColors[roll.result] || '#888'}">
+                          {p.type}: +${(p.principal + p.profit).toFixed(0)}
+                        </span>
+                      {/each}
+                    {:else}
+                      —
+                    {/if}
+                  </td>
+                </tr>
+              {/each}
+            </tbody>
+          </table>
+        </div>
+      {/if}
     {/if}
   {/if}
 {/if}

--- a/static/craps/index.html
+++ b/static/craps/index.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tom Hummel :: Craps Simulator</title>
+  <script type="importmap">
+  {
+    "imports": {
+      "svelte/internal": "https://cdn.jsdelivr.net/npm/svelte@3.59.2/internal/index.mjs"
+    }
+  }
+  </script>
+</head>
+<body>
+  <div id="app"></div>
+  <script>
+    function log(msg) {
+      let pre = document.getElementById('log');
+      if (!pre) {
+        pre = document.createElement('pre');
+        pre.id = 'log';
+        pre.style.color = 'red';
+        pre.style.whiteSpace = 'pre-wrap';
+        document.body.appendChild(pre);
+      }
+      pre.textContent += (pre.textContent ? '\n' : '') + msg;
+    }
+
+    window.addEventListener('error', (e) => log(e.error?.stack || e.message));
+    window.addEventListener('unhandledrejection', (e) => log(e.reason?.stack || e.reason));
+  </script>
+  <script type="module">
+    import { compile } from 'https://cdn.jsdelivr.net/npm/svelte@3.59.2/compiler.mjs';
+
+    async function main() {
+      try {
+        const res = await fetch('App.svelte');
+        if (!res.ok) throw new Error(`failed to load App.svelte: ${res.status}`);
+        const source = await res.text();
+
+        const { js, css } = compile(source, { generate: 'dom', format: 'esm', name: 'App' });
+
+        if (css.code) {
+          const style = document.createElement('style');
+          style.textContent = css.code;
+          document.head.appendChild(style);
+        }
+
+        const { default: App } = await import(`data:text/javascript,${encodeURIComponent(js.code)}`);
+        new App({ target: document.getElementById('app') });
+      } catch (err) {
+        log(err.stack || err);
+        console.error(err);
+      }
+    }
+    main();
+  </script>
+</body>
+</html>

--- a/static/craps/index.html
+++ b/static/craps/index.html
@@ -7,6 +7,7 @@
   <script type="importmap">
   {
     "imports": {
+      "svelte":          "https://cdn.jsdelivr.net/npm/svelte@3.59.2/index.mjs",
       "svelte/internal": "https://cdn.jsdelivr.net/npm/svelte@3.59.2/internal/index.mjs"
     }
   }


### PR DESCRIPTION
Ports node-craps game logic (settle, betting, core shoot/playHand) to a
browser-compatible Svelte tool. Users can pick a betting strategy, set
sessions/min-bet/max-odds, and see aggregate stats plus roll-by-roll history.

https://claude.ai/code/session_01KhktRDkLLRihoAMsCs8emh