### PR TITLE
Add service worker for offline support on craps simulator

### DIFF
--- a/static/craps/index.html
+++ b/static/craps/index.html
@@ -57,5 +57,11 @@
     }
     main();
   </script>
+  <script>
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('/craps/sw.js', { scope: '/craps/' })
+        .catch(err => console.warn('SW registration failed:', err));
+    }
+  </script>
 </body>
 </html>

--- a/static/craps/sw.js
+++ b/static/craps/sw.js
@@ -1,0 +1,39 @@
+const CACHE_NAME = 'craps-v1';
+
+const PRECACHE = [
+  '/craps/',
+  '/craps/App.svelte',
+  'https://cdn.jsdelivr.net/npm/svelte@3.59.2/index.mjs',
+  'https://cdn.jsdelivr.net/npm/svelte@3.59.2/internal/index.mjs',
+  'https://cdn.jsdelivr.net/npm/svelte@3.59.2/compiler.mjs',
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(PRECACHE))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k)))
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(cached => {
+      if (cached) return cached;
+      return fetch(event.request).then(response => {
+        if (response && response.ok) {
+          caches.open(CACHE_NAME).then(cache => cache.put(event.request, response.clone()));
+        }
+        return response;
+      });
+    })
+  );
+});


### PR DESCRIPTION
Registers a service worker scoped to /craps/ that pre-caches the page,
App.svelte, and Svelte CDN assets on install, then caches all other
fetched resources (including esm.sh node-craps module) as they are
loaded. After the first online visit, the simulator works fully offline.

https://claude.ai/code/session_01JGUa5oBGvwcfHBZpFNHf8y