### PR TITLE
Add Craps Roguelike lab: design doc, content pages, and Svelte prototype

### DIFF
--- a/content/experiments.md
+++ b/content/experiments.md
@@ -11,3 +11,4 @@ date: 2020-09-01T08:00:00
 - [Borfin Shlump](/borfin-shlump)
 - [Card Shuffle](/card-shuffle-svelte)
 - [Craps Simulator](/craps)
+- [Craps Roguelike (Lab)](/craps-roguelike)

--- a/content/lab/_index.md
+++ b/content/lab/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Lab"
+date: 2026-04-18
+---
+
+- [Craps Roguelike](/lab/craps-roguelike/)

--- a/content/lab/craps-roguelike/_index.md
+++ b/content/lab/craps-roguelike/_index.md
@@ -1,0 +1,9 @@
+---
+title: "Craps Roguelike"
+date: 2026-04-18
+---
+
+This lab now includes a first implementation of the run/stage simulator loop.
+
+- App: [/craps-roguelike/](/craps-roguelike/)
+- Design doc: [design.md](/lab/craps-roguelike/design/)

--- a/content/lab/craps-roguelike/design.md
+++ b/content/lab/craps-roguelike/design.md
@@ -1,0 +1,454 @@
+---
+title: "Roguelike Craps: Svelte Game Loop Design (v2)"
+date: 2026-04-18
+---
+
+This design turns your `node-craps` simulator into a "run-based" browser game:
+
+- You start with a bankroll.
+- You choose a strategy (loaded dynamically from `node-craps`) and stop boundaries.
+- You simulate hands until one boundary is hit.
+- You choose the next strategy and continue the same run.
+- The run ends when bankroll reaches 0 (bust) or target goal (win).
+
+## Core Product Shape
+
+### Main loop
+
+1. **Initialize run**
+   - `startingBankroll`
+   - `goalBankroll`
+   - optional `maxTotalHands` for the entire run
+2. **Create stage** (a stage is one strategy segment)
+   - choose `strategy`
+   - choose stage exit criteria
+3. **Simulate stage** hand-by-hand
+4. **Stop stage** when first boundary is hit
+5. **Apply stage result** to run history
+6. If run still active, return to strategy selection
+7. End run with `BUST`, `GOAL_REACHED`, or `TOTAL_HANDS_REACHED`
+
+This is effectively a finite state machine (FSM), which maps well to Svelte stores.
+
+## Domain Model
+
+```ts
+type RunStatus = 'SETUP' | 'READY_FOR_STAGE' | 'RUNNING_STAGE' | 'STAGE_COMPLETE' | 'RUN_COMPLETE'
+
+type RunEndReason = 'BUST' | 'GOAL_REACHED' | 'TOTAL_HANDS_REACHED'
+
+type StageExitReason =
+  | 'HIT_HIGH_WATER'
+  | 'HIT_LOW_WATER'
+  | 'HIT_STAGE_HAND_LIMIT'
+  | 'HIT_TOTAL_HAND_LIMIT'
+  | 'BUST'
+  | 'GOAL_REACHED'
+
+type StrategyId = string
+
+interface StrategyDefinition {
+  id: StrategyId
+  name: string
+  description?: string
+  riskTags?: string[]
+}
+
+interface RunConfig {
+  startingBankroll: number
+  goalBankroll: number
+  maxTotalHands?: number
+  seed?: string
+}
+
+interface StageConfig {
+  strategyId: StrategyId
+  highWaterMark?: number // absolute bankroll
+  lowWaterMark?: number  // absolute bankroll
+  maxHands?: number
+  speed: 'instant' | 'fast' | 'step'
+}
+
+interface HandResult {
+  runId: string
+  stageNumber: number
+  handNumber: number
+  strategyId: StrategyId
+  bankrollBefore: number
+  bankrollAfter: number
+  net: number
+  summary: string
+  startedAtIso: string
+  completedAtIso: string
+  rolls: number[]
+  events: string[]
+  detail?: Record<string, unknown> // full payload from node-craps for expandable view
+}
+
+interface StageResult {
+  runId: string
+  stageNumber: number
+  strategyId: StrategyId
+  startedAtBankroll: number
+  endedAtBankroll: number
+  handsPlayed: number
+  exitReason: StageExitReason
+  pnl: number
+  startedAtIso: string
+  completedAtIso: string
+}
+
+interface RunTranscript {
+  runId: string
+  startedAtIso: string
+  completedAtIso?: string
+  runConfig: RunConfig
+  stageResults: StageResult[]
+  hands: HandResult[]
+  finalBankroll: number
+  endReason?: RunEndReason
+}
+```
+
+## Svelte Architecture
+
+## Routes / pages
+
+- `/play` route for active simulation:
+  - `src/routes/play/+page.svelte`
+- `/history` route for previous runs:
+  - `src/routes/history/+page.svelte`
+- Optional component split:
+  - `RunSetupPanel.svelte`
+  - `StageSetupPanel.svelte`
+  - `SimulationControls.svelte`
+  - `BankrollChart.svelte`
+  - `TranscriptTable.svelte`
+  - `HandRow.svelte` (collapsed summary + expandable details)
+  - `RunHistoryTable.svelte`
+
+## Store design
+
+Use a central writable store (or a small store module) to hold run + stage state:
+
+```ts
+interface GameState {
+  status: RunStatus
+  runConfig: RunConfig | null
+  availableStrategies: StrategyDefinition[]
+  bankroll: number
+  totalHands: number
+  stageNumber: number
+  currentStage: StageConfig | null
+  stageHands: number
+  history: StageResult[]
+  handLog: HandResult[] // current run transcript
+  runId: string | null
+  runEndReason?: RunEndReason
+}
+```
+
+Derived stores:
+
+- `canStartRun`
+- `canStartStage`
+- `isRunning`
+- `roi`
+- `distanceToGoal`
+- `canExportTranscript`
+- `allRunsFromStorage`
+
+## Engine Integration (`node-craps`)
+
+Wrap your simulator behind a tiny adapter so UI never depends on raw library calls:
+
+```ts
+interface CrapsEngine {
+  listStrategies(): StrategyDefinition[]
+  setRollSequence?(rolls: number[]): void // deterministic testing hook (optional in production)
+  nextHand(input: {
+    bankroll: number
+    strategyId: StrategyId
+    tableState?: unknown
+  }): {
+    bankrollAfter: number
+    tableState?: unknown
+    detail: HandResult
+  }
+}
+```
+
+This allows you to:
+
+- source strategies directly from the library (no duplicated hard-coded list)
+- swap strategies cleanly between stages
+- support deterministic replay with seeded RNG
+- test loop logic independent of rendering
+
+### Engine injection rule
+
+The game loop should depend on an engine interface, not a concrete `node-craps` import:
+
+```ts
+interface GameLoopDeps {
+  engine: CrapsEngine
+  now: () => string
+  randomSeed?: string
+}
+```
+
+In production, pass your real `node-craps` adapter.
+In tests, pass a fake engine that returns scripted hand outcomes.
+
+### Strategy loading rule
+
+On app boot, call `engine.listStrategies()` and store the result in `availableStrategies`.
+If the library adds/removes strategies, the UI automatically reflects that change.
+
+## Game Loop Algorithm
+
+Pseudo-code for a cancellable async loop:
+
+```ts
+while (state.status === 'RUNNING_STAGE') {
+  const result = engine.nextHand({ bankroll, strategyId, tableState })
+  applyHand(result)
+  appendToTranscript(result.detail)
+
+  const reason = evaluateBoundaries(state)
+  if (reason) {
+    finalizeStage(reason)
+    break
+  }
+
+  if (speed !== 'instant') await sleep(frameDelay)
+  await tick() // keep UI responsive
+}
+```
+
+### Boundary evaluation order (important)
+
+Use deterministic priority to avoid ambiguity when several boundaries are crossed in one hand:
+
+1. `bankroll <= 0` -> `BUST`
+2. `bankroll >= goalBankroll` -> `GOAL_REACHED`
+3. `bankroll >= highWaterMark` -> `HIT_HIGH_WATER`
+4. `bankroll <= lowWaterMark` -> `HIT_LOW_WATER`
+5. `stageHands >= maxHands` -> `HIT_STAGE_HAND_LIMIT`
+6. `totalHands >= maxTotalHands` -> `HIT_TOTAL_HAND_LIMIT`
+
+## UX Flow
+
+## Setup panel
+
+- Starting bankroll
+- Goal bankroll
+- Optional total hand cap
+- Seed (optional)
+
+CTA: **Start Run**
+
+## Stage panel (shown after run starts)
+
+- Strategy selector populated from `availableStrategies`
+- Stage boundaries:
+  - High water
+  - Low water
+  - Max hands
+- Speed selector (`step`, `fast`, `instant`)
+
+CTA: **Run Stage**
+
+## Live simulation panel
+
+- Current bankroll
+- Stage P/L
+- Total hands
+- Last hand outcome
+- Pause / Resume / Stop Stage
+- Hand transcript table:
+  - default row: hand summary (`hand #`, strategy, net, bankroll after)
+  - click row expands into full detail (`rolls`, event breakdown, bet resolution payload)
+
+## Run history (current run)
+
+- Table of stages
+- Sparkline chart for bankroll trajectory
+- "What happened" badges for each exit reason
+
+## Saved game history view
+
+- Separate `/history` screen listing all completed runs from browser storage.
+- Columns: run start/end time, starting bankroll, ending bankroll, peak bankroll, total hands, end reason.
+- Click a run to open full transcript and export options.
+
+## Browser storage plan
+
+Persist completed runs using `localStorage` (or IndexedDB if transcripts become large).
+
+Storage key proposal:
+
+```txt
+crapsRogue:runs:v1
+```
+
+Shape:
+
+```ts
+interface StoredRuns {
+  schemaVersion: 1
+  runs: RunTranscript[]
+}
+```
+
+Retention options:
+
+- keep all runs (default)
+- max N runs (e.g., 100) with oldest trimmed
+
+## Balancing and Feel (Roguelike Layer)
+
+To make it feel like a roguelike instead of a plain simulator:
+
+- **Meta-progression stats** (across runs):
+  - best bankroll peak
+  - longest survival by hands
+  - win rate by strategy
+- **Unlocks**:
+  - strategies unlocked after milestones
+  - optional modifiers (e.g., reduced max odds, hot table bonus)
+- **Risk events between stages**:
+  - choose one of 2 modifiers before next stage
+  - each has upside + downside
+
+Start simple: implement pure simulation first, add meta layer later.
+
+## Reporting / export
+
+- Provide **Download Report** button at run completion and in history detail view.
+- Supported formats:
+  - `JSON` (full fidelity transcript)
+  - `CSV` (stage summary + hand summary rows)
+- File naming:
+  - `craps-run-<runId>-<YYYYMMDD-HHmm>.json`
+  - `craps-run-<runId>-<YYYYMMDD-HHmm>.csv`
+
+## MVP Scope (first shippable version)
+
+1. Single page with 3 panels: run setup, stage setup, results
+2. Dynamic strategy list from `node-craps` (no hard-coded list)
+3. Stage boundaries: high/low/max-hands
+4. Run end: bust or goal
+5. Hand transcript (summary rows with expandable details)
+6. One bankroll chart
+7. Run report export (JSON at minimum)
+8. Persistent history page backed by browser storage
+
+Defer until v2:
+
+- animation polish
+- unlock system
+- achievements
+- sharable run seed links
+
+## Testing Plan
+
+## Automated test strategy (game-specific only)
+
+Goal: test only your game loop + mechanics (not `node-craps` internals).
+
+Approach:
+
+1. Keep all run/stage mechanics in pure functions where possible.
+2. Inject dependencies (`engine`, clock, RNG seed source) into the loop runner.
+3. Use either:
+   - deterministic roll sequences via `engine.setRollSequence(...)`, or
+   - a full fake engine that returns exact scripted `HandResult` values.
+4. Assert only game-owned behavior:
+   - ending criteria
+   - stage exit criteria
+   - precedence order
+   - transcript construction
+   - storage/export behavior
+
+## Unit tests
+
+- `evaluateBoundaries` priority and correctness
+- stage finalization math (P/L, hand counts)
+- run completion triggers
+- transcript append/expand model transformation correctness
+- storage key serialization/deserialization (`crapsRogue:runs:v1`)
+
+## Integration tests
+
+- start run -> run stage -> stage complete -> run complete
+- switch strategies between stages preserves bankroll
+- deterministic seed yields identical stage results
+- strategies shown in UI exactly match `engine.listStrategies()`
+- completed run appears in `/history` after reload
+- exported JSON can be re-imported and parsed
+- deterministic roll sequence yields identical exit reason and transcript
+- fake-engine scenario can force each exit reason independently
+
+## Manual QA checklist
+
+- high and low water crossed near same hand uses correct priority
+- rapid instant mode does not freeze UI
+- pause/resume works without double-counting hands
+- resetting starts a clean run
+- hand rows are collapsed by default and expand correctly on click
+- exporting report downloads a valid file with expected naming
+- prior runs remain available after browser refresh
+
+## Example test harness patterns
+
+### Pattern A: deterministic dice sequence using real adapter
+
+Use this when you want confidence the adapter wiring is correct while still stabilizing outcomes.
+
+```ts
+const engine = createNodeCrapsAdapter()
+engine.setRollSequence?.([7, 11, 2, 3, 12, 6, 8, 7])
+
+const runner = createGameRunner({ engine, now: fixedClock('2026-04-18T00:00:00Z') })
+const result = runner.runStage(...)
+expect(result.exitReason).toBe('HIT_HIGH_WATER')
+```
+
+### Pattern B: fake engine for pure game-loop mechanics
+
+Use this as the default for automation so tests do not re-test `node-craps`.
+
+```ts
+const engine = createFakeEngine({
+  strategies: [{ id: 'any', name: 'Any' }],
+  hands: [
+    { net: +10, bankrollAfter: 110 },
+    { net: -30, bankrollAfter: 80 },
+  ],
+})
+
+const runner = createGameRunner({ engine, now: fixedClock('2026-04-18T00:00:00Z') })
+const result = runner.runStage(...)
+expect(result.exitReason).toBe('HIT_LOW_WATER')
+```
+
+Recommended split:
+
+- ~80% tests use fake engine (fast, deterministic, game-only)
+- ~20% tests use deterministic roll sequence on real adapter (wiring confidence)
+
+## Suggested Implementation Order
+
+1. Add `GameState` store and FSM transitions
+2. Build run setup form and stage setup form
+3. Implement simulator adapter (`node-craps` wrapper)
+4. Implement async stage loop with cancellation
+5. Add transcript table (summary + expandable hand details)
+6. Add history persistence and `/history` route
+7. Add JSON/CSV export
+8. Add seed + replay support
+
+---
+
+If you want, the next step is for me to sketch concrete Svelte component props/events and a TypeScript `gameEngine.ts` scaffold you can drop directly into your app.

--- a/static/craps-roguelike/App.svelte
+++ b/static/craps-roguelike/App.svelte
@@ -1,0 +1,313 @@
+<script>
+  const STORAGE_KEY = 'crapsRogue:runs:v1';
+
+  function createMockEngine() {
+    const strategies = [
+      { id: 'pass-line', name: 'Pass Line' },
+      { id: 'dont-pass', name: "Don't Pass" },
+      { id: 'come', name: 'Come Bet' }
+    ];
+
+    let scriptedRolls = [];
+
+    return {
+      listStrategies() {
+        return strategies;
+      },
+      setRollSequence(rolls) {
+        scriptedRolls = [...rolls];
+      },
+      nextHand({ bankroll, strategyId, handNumber }) {
+        const die = scriptedRolls.length ? scriptedRolls.shift() : (Math.floor(Math.random() * 11) + 2);
+        const net = die >= 8 ? 10 : die <= 4 ? -10 : 0;
+        return {
+          bankrollAfter: Math.max(0, bankroll + net),
+          detail: {
+            handNumber,
+            strategyId,
+            bankrollBefore: bankroll,
+            bankrollAfter: Math.max(0, bankroll + net),
+            net,
+            summary: `Rolled ${die}; net ${net >= 0 ? '+' : ''}${net}`,
+            rolls: [die],
+            events: [`strategy=${strategyId}`, `die=${die}`],
+            detail: { die, scripted: scriptedRolls.length >= 0 }
+          }
+        };
+      }
+    };
+  }
+
+  const engine = createMockEngine();
+  let availableStrategies = engine.listStrategies();
+
+  let run = null;
+  let bankroll = 0;
+  let totalHands = 0;
+  let status = 'SETUP';
+  let stageNumber = 0;
+  let stageHands = 0;
+  let stageHistory = [];
+  let handLog = [];
+  let expandedRows = {};
+  let running = false;
+  let runHistory = [];
+
+  let runConfig = { startingBankroll: 300, goalBankroll: 500, maxTotalHands: 300 };
+  let stageConfig = { strategyId: '', highWaterMark: 0, lowWaterMark: 0, maxHands: 30, speedMs: 20 };
+  let rollSequenceInput = '';
+
+  function loadHistory() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return;
+      const parsed = JSON.parse(raw);
+      runHistory = parsed.runs || [];
+    } catch {
+      runHistory = [];
+    }
+  }
+
+  function saveHistory() {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ schemaVersion: 1, runs: runHistory }));
+  }
+
+  function startRun() {
+    bankroll = Number(runConfig.startingBankroll);
+    totalHands = 0;
+    stageNumber = 0;
+    stageHands = 0;
+    stageHistory = [];
+    handLog = [];
+    run = {
+      runId: crypto.randomUUID(),
+      startedAtIso: new Date().toISOString(),
+      runConfig: { ...runConfig },
+      stageResults: [],
+      hands: [],
+      finalBankroll: bankroll
+    };
+    stageConfig.strategyId = availableStrategies[0]?.id || '';
+    status = 'READY_FOR_STAGE';
+  }
+
+  function applyRollSequence() {
+    const seq = rollSequenceInput
+      .split(',')
+      .map((s) => Number(s.trim()))
+      .filter((n) => Number.isFinite(n));
+
+    if (seq.length && engine.setRollSequence) {
+      engine.setRollSequence(seq);
+    }
+  }
+
+  function evaluateExit() {
+    if (bankroll <= 0) return 'BUST';
+    if (bankroll >= Number(runConfig.goalBankroll)) return 'GOAL_REACHED';
+    if (Number(stageConfig.highWaterMark) > 0 && bankroll >= Number(stageConfig.highWaterMark)) return 'HIT_HIGH_WATER';
+    if (Number(stageConfig.lowWaterMark) > 0 && bankroll <= Number(stageConfig.lowWaterMark)) return 'HIT_LOW_WATER';
+    if (stageHands >= Number(stageConfig.maxHands)) return 'HIT_STAGE_HAND_LIMIT';
+    if (Number(runConfig.maxTotalHands) > 0 && totalHands >= Number(runConfig.maxTotalHands)) return 'HIT_TOTAL_HAND_LIMIT';
+    return null;
+  }
+
+  function finalizeStage(exitReason, startedAtBankroll) {
+    const result = {
+      stageNumber,
+      strategyId: stageConfig.strategyId,
+      startedAtBankroll,
+      endedAtBankroll: bankroll,
+      handsPlayed: stageHands,
+      exitReason,
+      pnl: bankroll - startedAtBankroll,
+      completedAtIso: new Date().toISOString()
+    };
+
+    stageHistory = [...stageHistory, result];
+    run.stageResults = [...run.stageResults, result];
+
+    if (exitReason === 'BUST' || exitReason === 'GOAL_REACHED' || exitReason === 'HIT_TOTAL_HAND_LIMIT') {
+      status = 'RUN_COMPLETE';
+      run.completedAtIso = new Date().toISOString();
+      run.finalBankroll = bankroll;
+      run.endReason = exitReason;
+      run.hands = [...handLog];
+      runHistory = [run, ...runHistory].slice(0, 100);
+      saveHistory();
+    } else {
+      status = 'READY_FOR_STAGE';
+    }
+  }
+
+  async function runStage() {
+    if (!run || running) return;
+    running = true;
+    stageNumber += 1;
+    stageHands = 0;
+    const startedAtBankroll = bankroll;
+    status = 'RUNNING_STAGE';
+
+    while (running) {
+      const handNumber = totalHands + 1;
+      const { detail, bankrollAfter } = engine.nextHand({ bankroll, strategyId: stageConfig.strategyId, handNumber });
+      bankroll = bankrollAfter;
+      totalHands += 1;
+      stageHands += 1;
+      handLog = [...handLog, { ...detail, stageNumber, runId: run.runId }];
+
+      const exit = evaluateExit();
+      if (exit) {
+        running = false;
+        finalizeStage(exit, startedAtBankroll);
+        break;
+      }
+
+      await new Promise((r) => setTimeout(r, Math.max(0, Number(stageConfig.speedMs) || 0)));
+    }
+  }
+
+  function stopStage() {
+    running = false;
+    status = run ? 'READY_FOR_STAGE' : 'SETUP';
+  }
+
+  function toggleRow(index) {
+    expandedRows[index] = !expandedRows[index];
+    expandedRows = expandedRows;
+  }
+
+  function exportRun() {
+    if (!run || status !== 'RUN_COMPLETE') return;
+    const blob = new Blob([JSON.stringify(run, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+    a.href = url;
+    a.download = `craps-run-${run.runId}-${stamp}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  loadHistory();
+</script>
+
+<main>
+  <h1>Craps Roguelike (Lab)</h1>
+  <p>Early implementation of the run/stage loop with transcript, deterministic hooks, and local history.</p>
+
+  <section>
+    <h2>Run Setup</h2>
+    <label>Starting bankroll <input type="number" bind:value={runConfig.startingBankroll} /></label>
+    <label>Goal bankroll <input type="number" bind:value={runConfig.goalBankroll} /></label>
+    <label>Total hand cap <input type="number" bind:value={runConfig.maxTotalHands} /></label>
+    <button on:click={startRun}>Start Run</button>
+  </section>
+
+  <section>
+    <h2>Stage Setup</h2>
+    <label>Strategy
+      <select bind:value={stageConfig.strategyId}>
+        {#each availableStrategies as strategy}
+          <option value={strategy.id}>{strategy.name}</option>
+        {/each}
+      </select>
+    </label>
+    <label>High water <input type="number" bind:value={stageConfig.highWaterMark} /></label>
+    <label>Low water <input type="number" bind:value={stageConfig.lowWaterMark} /></label>
+    <label>Stage max hands <input type="number" bind:value={stageConfig.maxHands} /></label>
+    <label>Delay ms <input type="number" bind:value={stageConfig.speedMs} /></label>
+    <label>Deterministic roll sequence (comma separated)
+      <input type="text" bind:value={rollSequenceInput} placeholder="7,11,4,10" />
+    </label>
+    <div class="row">
+      <button on:click={applyRollSequence}>Apply Roll Sequence</button>
+      <button on:click={runStage} disabled={!run || running || !stageConfig.strategyId}>Run Stage</button>
+      <button on:click={stopStage} disabled={!running}>Stop Stage</button>
+    </div>
+  </section>
+
+  <section>
+    <h2>Live State</h2>
+    <p>Status: <strong>{status}</strong></p>
+    <p>Bankroll: <strong>{bankroll}</strong> | Total hands: <strong>{totalHands}</strong> | Stages: <strong>{stageHistory.length}</strong></p>
+    {#if status === 'RUN_COMPLETE'}
+      <button on:click={exportRun}>Download JSON report</button>
+    {/if}
+  </section>
+
+  <section>
+    <h2>Transcript (latest 25 hands)</h2>
+    <table>
+      <thead><tr><th>#</th><th>Stage</th><th>Summary</th><th>Net</th><th>Bankroll</th></tr></thead>
+      <tbody>
+        {#each handLog.slice(-25).reverse() as hand, i}
+          <tr on:click={() => toggleRow(i)}>
+            <td>{hand.handNumber}</td>
+            <td>{hand.stageNumber}</td>
+            <td>{hand.summary}</td>
+            <td>{hand.net}</td>
+            <td>{hand.bankrollAfter}</td>
+          </tr>
+          {#if expandedRows[i]}
+            <tr class="expanded">
+              <td colspan="5"><pre>{JSON.stringify(hand.detail, null, 2)}</pre></td>
+            </tr>
+          {/if}
+        {/each}
+      </tbody>
+    </table>
+  </section>
+
+  <section>
+    <h2>Saved Runs ({runHistory.length})</h2>
+    <ul>
+      {#each runHistory.slice(0, 10) as saved}
+        <li>{saved.startedAtIso} → {saved.completedAtIso || '-'} | {saved.runConfig.startingBankroll} → {saved.finalBankroll} ({saved.endReason || 'incomplete'})</li>
+      {/each}
+    </ul>
+  </section>
+</main>
+
+<style>
+  :global(body) {
+    margin: 0;
+    font-family: system-ui, sans-serif;
+    background: #10151a;
+    color: #f3f4f6;
+  }
+  main {
+    max-width: 1000px;
+    margin: 0 auto;
+    padding: 1rem;
+  }
+  section {
+    background: #1f2937;
+    border-radius: 8px;
+    padding: 0.8rem;
+    margin-bottom: 1rem;
+  }
+  label {
+    display: block;
+    margin: 0.35rem 0;
+  }
+  input, select, button {
+    margin-left: 0.5rem;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+  th, td {
+    border-bottom: 1px solid #374151;
+    padding: 0.35rem;
+    text-align: left;
+  }
+  tr { cursor: pointer; }
+  tr.expanded { cursor: default; }
+  pre {
+    white-space: pre-wrap;
+    margin: 0;
+  }
+  .row { display: flex; gap: 0.5rem; margin-top: 0.5rem; }
+</style>

--- a/static/craps-roguelike/index.html
+++ b/static/craps-roguelike/index.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tom Hummel :: Craps Roguelike (Lab)</title>
+  <script type="importmap">
+  {
+    "imports": {
+      "svelte/internal": "https://cdn.jsdelivr.net/npm/svelte@3.59.2/internal/index.mjs"
+    }
+  }
+  </script>
+</head>
+<body>
+  <div id="app"></div>
+  <script>
+    function log(msg) {
+      let pre = document.getElementById('log');
+      if (!pre) {
+        pre = document.createElement('pre');
+        pre.id = 'log';
+        pre.style.color = 'red';
+        pre.style.whiteSpace = 'pre-wrap';
+        document.body.appendChild(pre);
+      }
+      pre.textContent += (pre.textContent ? '\n' : '') + msg;
+    }
+
+    window.addEventListener('error', (e) => log(e.error?.stack || e.message));
+    window.addEventListener('unhandledrejection', (e) => log(e.reason?.stack || e.reason));
+  </script>
+  <script type="module">
+    import { compile } from 'https://cdn.jsdelivr.net/npm/svelte@3.59.2/compiler.mjs';
+
+    async function main() {
+      try {
+        const res = await fetch('App.svelte');
+        if (!res.ok) throw new Error(`failed to load App.svelte: ${res.status}`);
+        const source = await res.text();
+
+        const { js, css } = compile(source, { generate: 'dom', format: 'esm', name: 'App' });
+
+        if (css.code) {
+          const style = document.createElement('style');
+          style.textContent = css.code;
+          document.head.appendChild(style);
+        }
+
+        const { default: App } = await import(`data:text/javascript,${encodeURIComponent(js.code)}`);
+        new App({ target: document.getElementById('app') });
+      } catch (err) {
+        log(err.stack || err);
+        console.error(err);
+      }
+    }
+
+    main();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation

- Introduce a new "Craps Roguelike" lab to prototype a run-/stage-based game built on the existing `node-craps` simulator. 
- Provide a concrete design specification for the loop, domain model, and testing approach to avoid coupling UI to engine internals. 
- Ship a minimal static Svelte prototype to exercise the run/stage loop, deterministic hooks, transcript, and local run history. 

### Description

- Add site navigation and lab pages by updating `content/experiments.md` and creating `content/lab/_index.md` and `content/lab/craps-roguelike/_index.md`. 
- Add a comprehensive design document `content/lab/craps-roguelike/design.md` that defines the domain model, FSM states, engine interface, loop algorithm, UX, storage plan, and a testing strategy. 
- Add a static Svelte prototype under `static/craps-roguelike/` including `App.svelte` (implements a mock engine, run/stage loop, deterministic roll sequence input, transcript, local `localStorage` history, and export) and `index.html` (loads and compiles the Svelte component in the browser). 

### Testing

- No automated tests were added or executed as part of this change. 
- A detailed automated test plan is included in `content/lab/craps-roguelike/design.md` that outlines unit and integration tests, fake-engine patterns, and storage/export validation to be implemented in follow-ups.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da4af72e308323a24591a7bafb3da3)